### PR TITLE
Fix(CreateTable): Set default standardDefinition

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/bigquery/models/TableDefinition.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/models/TableDefinition.java
@@ -17,8 +17,7 @@ public class TableDefinition {
     private final io.kestra.plugin.gcp.bigquery.models.Schema schema;
 
     @Schema(title = "the table definition if the type is `TABLE`")
-    @Builder.Default
-    private final StandardTableDefinition standardTableDefinition = new StandardTableDefinition(null,null,null,null);
+    private final StandardTableDefinition standardTableDefinition;
 
     @Schema(title = "the materialized view definition if the type is `MATERIALIZED_VIEW`")
     private final MaterializedViewDefinition materializedViewDefinition;
@@ -64,7 +63,8 @@ public class TableDefinition {
             case VIEW:
                 return (T) this.viewDefinition.to(runContext);
             case TABLE:
-                return (T) this.standardTableDefinition.to(runContext, this.schema);
+                return (T) (this.standardTableDefinition == null ? StandardTableDefinition.builder().build() : this.standardTableDefinition)
+                    .to(runContext, this.schema);
             case EXTERNAL:
                 return (T) this.externalTableDefinition.to(runContext, this.schema);
             case MATERIALIZED_VIEW:

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/models/TableDefinition.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/models/TableDefinition.java
@@ -17,7 +17,8 @@ public class TableDefinition {
     private final io.kestra.plugin.gcp.bigquery.models.Schema schema;
 
     @Schema(title = "the table definition if the type is `TABLE`")
-    private final StandardTableDefinition standardTableDefinition;
+    @Builder.Default
+    private final StandardTableDefinition standardTableDefinition = new StandardTableDefinition(null,null,null,null);
 
     @Schema(title = "the materialized view definition if the type is `MATERIALIZED_VIEW`")
     private final MaterializedViewDefinition materializedViewDefinition;

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/CreateUpdateTableTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/CreateUpdateTableTest.java
@@ -92,4 +92,48 @@ class CreateUpdateTableTest {
         assertThat(updateRun.getFriendlyName(), is("new_table_2"));
         assertThat(updateRun.getExpirationTime(), is(not(run.getExpirationTime())));
     }
+
+    @Test
+    void runWithoutStandardDefinition() throws Exception {
+        String friendlyId = FriendlyId.createFriendlyId();
+
+        CreateTable task = CreateTable.builder()
+                .projectId(this.project)
+                .dataset(this.dataset)
+                .table(friendlyId)
+                .friendlyName("new_table")
+                .tableDefinition(TableDefinition.builder()
+                        .type(TableDefinition.Type.TABLE)
+                        .schema(Schema.builder()
+                                .fields(Arrays.asList(
+                                        Field.builder()
+                                                .name("id")
+                                                .type(StandardSQLTypeName.INT64)
+                                                .build(),
+                                        Field.builder()
+                                                .name("name")
+                                                .type(StandardSQLTypeName.STRING)
+                                                .build()
+                                ))
+                                .build()
+                        )
+                        .standardTableDefinition(StandardTableDefinition.builder()
+                                .clustering(Arrays.asList("id", "name"))
+                                .build()
+                        )
+                        .build()
+                )
+                .build();
+        RunContext runContext = runContextFactory.of(ImmutableMap.of());
+
+
+        CreateTable.Output run = task.run(runContext);
+
+        assertThat(run.getTable(), is(friendlyId));
+        assertThat(run.getFriendlyName(), is("new_table"));
+        assertThat(run.getDefinition().getSchema().getFields().size(), is(2));
+
+        assertThat(run.getDefinition().getSchema().getFields().get(0).getType(), is(StandardSQLTypeName.INT64));
+
+    }
 }

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/CreateUpdateTableTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/CreateUpdateTableTest.java
@@ -117,10 +117,6 @@ class CreateUpdateTableTest {
                                 ))
                                 .build()
                         )
-                        .standardTableDefinition(StandardTableDefinition.builder()
-                                .clustering(Arrays.asList("id", "name"))
-                                .build()
-                        )
                         .build()
                 )
                 .build();
@@ -134,6 +130,5 @@ class CreateUpdateTableTest {
         assertThat(run.getDefinition().getSchema().getFields().size(), is(2));
 
         assertThat(run.getDefinition().getSchema().getFields().get(0).getType(), is(StandardSQLTypeName.INT64));
-
     }
 }


### PR DESCRIPTION
If I want to create a standard table without buffer, cluster or partitioning, I cannot set the standardDefinition field.

This brings a nullPointer since no standardDefinition is provided.