### PR TITLE
Feat(Bigquery.Query): Added destination Table to output and log it

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
@@ -256,7 +256,6 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
                 ),
             this.dryRun
         );
-
         JobStatistics.QueryStatistics queryJobStatistics = queryJob.getStatistics();
 
         QueryJobConfiguration config = queryJob.getConfiguration();
@@ -299,10 +298,10 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
                     output.row(fetch.size() > 0 ? fetch.get(0) : ImmutableMap.of());
                 }
             }
-                DestinationTable destinationTable = new DestinationTable(tableIdentity.getProject(),tableIdentity.getDataset(),tableIdentity.getTable());
-                output.destinationTable(destinationTable);
         }
 
+        DestinationTable destinationTable = new DestinationTable(tableIdentity.getProject(),tableIdentity.getDataset(),tableIdentity.getTable());
+        output.destinationTable(destinationTable);
         return output.build();
     }
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
@@ -262,7 +262,7 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
         QueryJobConfiguration config = queryJob.getConfiguration();
         TableId tableIdentity = config.getDestinationTable();
 
-        logger.info("Query loaded in: {}", tableIdentity.getDataset() + "." + tableIdentity.getTable());
+        logger.debug("Query loaded in: {}", tableIdentity.getDataset() + "." + tableIdentity.getTable());
 
         this.metrics(runContext, queryJobStatistics, queryJob);
 
@@ -299,10 +299,7 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
                     output.row(fetch.size() > 0 ? fetch.get(0) : ImmutableMap.of());
                 }
             }
-                HashMap<String,String> destinationTable = new HashMap<>();
-                destinationTable.put("project",tableIdentity.getProject());
-                destinationTable.put("dataset",tableIdentity.getDataset());
-                destinationTable.put("table",tableIdentity.getTable());
+                DestinationTable destinationTable = new DestinationTable(tableIdentity.getProject(),tableIdentity.getDataset(),tableIdentity.getTable());
                 output.destinationTable(destinationTable);
         }
 
@@ -440,7 +437,7 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
         @Schema(
             title = "The informations where the data are stored"
         )
-        private HashMap<String,String> destinationTable;
+        private DestinationTable destinationTable;
     }
 
     private String[] tags(JobStatistics.QueryStatistics stats, Job queryJob) {
@@ -451,6 +448,40 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
             "project_id", queryJob.getJobId().getProject(),
             "location", queryJob.getJobId().getLocation(),
         };
+    }
+
+    public class DestinationTable {
+        @Schema(
+                title = "The project of the table"
+        )
+        private String project;
+        @Schema(
+                title = "The dataset of the table"
+        )
+        private String dataset;
+
+        @Schema(
+                title = "The table name"
+        )
+        private String table;
+
+        public DestinationTable(String project, String dataset, String table){
+            this.project = project;
+            this.dataset = dataset;
+            this.table = table;
+        }
+
+        public String getProject() {
+            return project;
+        }
+
+        public String getDataset() {
+            return dataset;
+        }
+
+        public String getTable() {
+            return table;
+        }
     }
 
     private void metrics(RunContext runContext, JobStatistics.QueryStatistics stats, Job queryJob) throws IllegalVariableEvaluationException {

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
@@ -300,7 +300,7 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
             }
         }
 
-        DestinationTable destinationTable = new DestinationTable(tableIdentity.getProject(),tableIdentity.getDataset(),tableIdentity.getTable());
+        DestinationTable destinationTable = new DestinationTable(tableIdentity.getProject(), tableIdentity.getDataset(), tableIdentity.getTable());
         output.destinationTable(destinationTable);
         return output.build();
     }
@@ -434,7 +434,7 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
         private URI uri;
 
         @Schema(
-            title = "The informations where the data are stored"
+            title = "The destination table (if one) or the temporary table created automatically "
         )
         private DestinationTable destinationTable;
     }

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
@@ -294,6 +294,10 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
                     output.row(fetch.size() > 0 ? fetch.get(0) : ImmutableMap.of());
                 }
             }
+            if (this.destinationTable != null) {
+                output.destinationTable(this.destinationTable);
+                logger.info("Query loaded in: {}",this.destinationTable);
+            }
         }
 
         return output.build();
@@ -426,6 +430,12 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
             description = "Only populated if 'store' is set to true."
         )
         private URI uri;
+
+        @Schema(
+            title = "The table where the data are stored",
+            description = "Only populated if 'destinationTable' is set."
+        )
+        private String destinationTable;
     }
 
     private String[] tags(JobStatistics.QueryStatistics stats, Job queryJob) {

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
@@ -259,6 +259,11 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
 
         JobStatistics.QueryStatistics queryJobStatistics = queryJob.getStatistics();
 
+        QueryJobConfiguration config = queryJob.getConfiguration();
+        TableId tableIdentity = config.getDestinationTable();
+
+        logger.info("Query loaded in: {}", tableIdentity.getDataset() + "." + tableIdentity.getTable());
+
         this.metrics(runContext, queryJobStatistics, queryJob);
 
         Output.OutputBuilder output = Output.builder()
@@ -294,10 +299,11 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
                     output.row(fetch.size() > 0 ? fetch.get(0) : ImmutableMap.of());
                 }
             }
-            if (this.destinationTable != null) {
-                output.destinationTable(this.destinationTable);
-                logger.info("Query loaded in: {}",this.destinationTable);
-            }
+                HashMap<String,String> destinationTable = new HashMap<>();
+                destinationTable.put("project",tableIdentity.getProject());
+                destinationTable.put("dataset",tableIdentity.getProject());
+                destinationTable.put("table",tableIdentity.getProject());
+                output.destinationTable(destinationTable);
         }
 
         return output.build();
@@ -432,10 +438,9 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
         private URI uri;
 
         @Schema(
-            title = "The table where the data are stored",
-            description = "Only populated if 'destinationTable' is set."
+            title = "The informations where the data are stored"
         )
-        private String destinationTable;
+        private HashMap<String,String> destinationTable;
     }
 
     private String[] tags(JobStatistics.QueryStatistics stats, Job queryJob) {

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
@@ -301,8 +301,8 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
             }
                 HashMap<String,String> destinationTable = new HashMap<>();
                 destinationTable.put("project",tableIdentity.getProject());
-                destinationTable.put("dataset",tableIdentity.getProject());
-                destinationTable.put("table",tableIdentity.getProject());
+                destinationTable.put("dataset",tableIdentity.getDataset());
+                destinationTable.put("table",tableIdentity.getTable());
                 output.destinationTable(destinationTable);
         }
 

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/QueryTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/QueryTest.java
@@ -52,7 +52,7 @@ class QueryTest {
     @Value("${kestra.tasks.bigquery.dataset}")
     private String dataset;
 
-        static String sql() {
+    static String sql() {
         return "SELECT \n" +
             "  \"hello\" as string,\n" +
             "  CAST(NULL AS INT) AS `nullable`,\n" +

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/QueryTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/QueryTest.java
@@ -46,13 +46,13 @@ class QueryTest {
     @Inject
     private StorageInterface storageInterface;
 
-    @Value("${kestra.tasks.bigquery.project}")
+    @Value("lmfr-ddp-dcp-dev")
     private String project;
 
-    @Value("${kestra.tasks.bigquery.dataset}")
+    @Value("tests")
     private String dataset;
 
-    static String sql() {
+        static String sql() {
         return "SELECT \n" +
             "  \"hello\" as string,\n" +
             "  CAST(NULL AS INT) AS `nullable`,\n" +
@@ -80,6 +80,7 @@ class QueryTest {
 
         Query task = Query.builder()
             .sql("{{sql}}")
+            .location("EU")
             .fetch(true)
             .build();
 
@@ -140,6 +141,7 @@ class QueryTest {
 
     @Test
     void destination() throws Exception {
+        String friendlyId = FriendlyId.createFriendlyId();
         Query task = Query.builder()
             .id(QueryTest.class.getSimpleName())
             .type(Query.class.getName())
@@ -151,7 +153,7 @@ class QueryTest {
                 "{{ loop.last  == false ? '\nUNION ALL\n' : '\n' }}" +
                 "{% endfor %}"
             )
-            .destinationTable(project + "." + dataset + "." + FriendlyId.createFriendlyId())
+            .destinationTable(project + "." + dataset + "." + friendlyId)
             .timePartitioningField("execution_date")
             .clusteringFields(Arrays.asList("execution_id", "counter"))
             .schemaUpdateOptions(Collections.singletonList(JobInfo.SchemaUpdateOption.ALLOW_FIELD_ADDITION))
@@ -164,6 +166,9 @@ class QueryTest {
 
         Query.Output run = task.run(runContext);
         assertThat(run.getJobId(), is(notNullValue()));
+        assertThat(run.getDestinationTable().getProject(),is(project));
+        assertThat(run.getDestinationTable().getDataset(),is(dataset));
+        assertThat(run.getDestinationTable().getTable(),is(friendlyId));
     }
 
     @Test

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/QueryTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/QueryTest.java
@@ -46,10 +46,10 @@ class QueryTest {
     @Inject
     private StorageInterface storageInterface;
 
-    @Value("lmfr-ddp-dcp-dev")
+    @Value("${kestra.tasks.bigquery.project}")
     private String project;
 
-    @Value("tests")
+    @Value("${kestra.tasks.bigquery.dataset}")
     private String dataset;
 
         static String sql() {


### PR DESCRIPTION
Our users would like to know in which table the query have been loaded without having to go in the flow (also useful when your table name is generated from multiple variables)

edit: I also added the destinationTable in the output so it can be reused in the flow.