### PR TITLE
fix: use the executionId from the runContext for all triggers

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Trigger.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Trigger.java
@@ -106,15 +106,13 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
             return Optional.empty();
         }
 
-        String executionId = IdUtils.create();
-
         ExecutionTrigger executionTrigger = ExecutionTrigger.of(
             this,
             run
         );
 
         Execution execution = Execution.builder()
-            .id(executionId)
+            .id(runContext.getTriggerExecutionId())
             .namespace(context.getNamespace())
             .flowId(context.getFlowId())
             .flowRevision(context.getFlowRevision())

--- a/src/main/java/io/kestra/plugin/gcp/gcs/Downloads.java
+++ b/src/main/java/io/kestra/plugin/gcp/gcs/Downloads.java
@@ -152,7 +152,6 @@ public class Downloads extends AbstractGcs implements RunnableTask<Downloads.Out
         @Schema(
             title = "The bucket of the downloaded file"
         )
-        @PluginProperty(additionalProperties = Blob.class)
         private final java.util.List<Blob>  blobs;
     }
 }

--- a/src/main/java/io/kestra/plugin/gcp/gcs/Trigger.java
+++ b/src/main/java/io/kestra/plugin/gcp/gcs/Trigger.java
@@ -114,8 +114,6 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
             return Optional.empty();
         }
 
-        String executionId = IdUtils.create();
-
         Storage connection = task.connection(runContext);
 
         java.util.List<Blob> list = run
@@ -124,7 +122,7 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
             .map(throwFunction(blob -> {
                 URI uri = runContext.putTempFile(
                     Download.download(runContext, connection, BlobId.of(blob.getBucket(), blob.getName())),
-                    executionId,
+                    runContext.getTriggerExecutionId(),
                     this
                 );
 
@@ -148,7 +146,7 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
         );
 
         Execution execution = Execution.builder()
-            .id(executionId)
+            .id(runContext.getTriggerExecutionId())
             .namespace(context.getNamespace())
             .flowId(context.getFlowId())
             .flowRevision(context.getFlowRevision())

--- a/src/main/java/io/kestra/plugin/gcp/pubsub/Trigger.java
+++ b/src/main/java/io/kestra/plugin/gcp/pubsub/Trigger.java
@@ -104,15 +104,13 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
             return Optional.empty();
         }
 
-        String executionId = IdUtils.create();
-
         ExecutionTrigger executionTrigger = ExecutionTrigger.of(
             this,
             run
         );
 
         Execution execution = Execution.builder()
-            .id(executionId)
+            .id(runContext.getTriggerExecutionId())
             .namespace(context.getNamespace())
             .flowId(context.getFlowId())
             .flowRevision(context.getFlowRevision())


### PR DESCRIPTION
Needs https://github.com/kestra-io/kestra/pull/1277 to be build