### PR TITLE
feat: Multi-modal completion thanks to Gemeni Generative AI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ dependencies {
     api 'androidx.annotation:annotation:1.6.0'
     api 'net.jodah:failsafe:2.4.4'
 
-    api platform('com.google.cloud:libraries-bom:26.23.0')
+    api platform('com.google.cloud:libraries-bom:26.29.0')
     api 'com.google.cloud:google-cloud-storage'
     api 'com.google.cloud:google-cloud-bigquery'
     api 'com.google.cloud:google-cloud-bigquerystorage'
@@ -73,6 +73,7 @@ dependencies {
     api 'com.google.cloud:google-cloud-firestore'
     api 'com.google.cloud:google-cloud-pubsub'
     api 'com.google.cloud:google-cloud-dataproc'
+    api 'com.google.cloud:google-cloud-vertexai'
 }
 
 

--- a/src/main/java/io/kestra/plugin/gcp/vertexai/MultimodalCompletion.java
+++ b/src/main/java/io/kestra/plugin/gcp/vertexai/MultimodalCompletion.java
@@ -1,0 +1,204 @@
+package io.kestra.plugin.gcp.vertexai;
+
+import com.google.cloud.vertexai.VertexAI;
+import com.google.cloud.vertexai.api.Candidate;
+import com.google.cloud.vertexai.api.GenerateContentResponse;
+import com.google.cloud.vertexai.api.GenerationConfig;
+import com.google.cloud.vertexai.api.Part;
+import com.google.cloud.vertexai.generativeai.preview.ContentMaker;
+import com.google.cloud.vertexai.generativeai.preview.GenerativeModel;
+import com.google.cloud.vertexai.generativeai.preview.PartMaker;
+import com.google.cloud.vertexai.generativeai.preview.ResponseHandler;
+import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.executions.metrics.Counter;
+import io.kestra.core.models.flows.State;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.runners.RunContext;
+import io.micronaut.http.MutableHttpRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Multimodal completion using the Vertex AI Gemini large language models (LLM)",
+    description = "See [Overview of multimodal models](https://cloud.google.com/vertex-ai/docs/generative-ai/multimodal/overview) for more information."
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Text completion using the Vertex Gemini API",
+            code = {
+                """
+                    region: us-central1
+                    projectId: my-project
+                    contents:
+                      - content: Please tell me a joke"""
+            }),
+        @Example(
+            title = "Multimodal completion using the Vertex Gemini API",
+            code = {
+                """
+                    region: us-central1
+                    projectId: my-project
+                    contents:
+                      - content: Can you describe this image?
+                      - mimeType: image/jpeg
+                        content: "{{ inputs.image }"""
+            })
+    }
+)
+public class MultimodalCompletion extends AbstractGenerativeAi implements RunnableTask<MultimodalCompletion.Output> {
+    private static final String MODEL_ID = "gemini-pro-vision";
+
+
+    @Schema(
+        title = "The contents"
+    )
+    @PluginProperty(dynamic = true)
+    @NotEmpty
+    private List<Content> contents;
+
+    @Override
+    public MultimodalCompletion.Output run(RunContext runContext) throws Exception {
+        String projectId = runContext.render(this.getProjectId());
+        String region = runContext.render(this.getRegion());
+
+        try (VertexAI vertexAI = new VertexAI(projectId, region, this.credentials(runContext))) {
+            var parts = contents.stream().map( content -> content.getMimeType() == null ? content.getContent() : createPart(runContext, content)).toList();
+
+            GenerativeModel model = new GenerativeModel(MODEL_ID, vertexAI);
+            if (this.getParameters() != null) {
+                var config = GenerationConfig.newBuilder();
+                config.setTemperature(this.getParameters().getTemperature());
+                config.setMaxOutputTokens(this.getParameters().getMaxOutputTokens());
+                config.setTopK(this.getParameters().getTopK());
+                config.setTopP(this.getParameters().getTopP());
+                model.setGenerationConfig(config.build());
+            }
+
+            GenerateContentResponse response = model.generateContent(ContentMaker.fromMultiModalData(parts.toArray()));
+            runContext.logger().debug(response.toString());
+
+            runContext.metric(Counter.of("candidate.token.count", response.getUsageMetadata().getCandidatesTokenCount()));
+            runContext.metric(Counter.of("prompt.token.count", response.getUsageMetadata().getPromptTokenCount()));
+            runContext.metric(Counter.of("total.token.count", response.getUsageMetadata().getTotalTokenCount()));
+            runContext.metric(Counter.of("serialized.size", response.getUsageMetadata().getSerializedSize()));
+
+            var finishReason = ResponseHandler.getFinishReason(response);
+            var safetyRatings = response.getCandidates(0).getSafetyRatingsList().stream()
+                .map(safetyRating -> new SafetyRating(safetyRating.getCategory().name(), safetyRating.getProbability().name(), safetyRating.getBlocked()))
+                .toList();
+            var output = Output.builder()
+                .finishReason(finishReason.name())
+                .safetyRatings(safetyRatings);
+
+            if (finishReason == Candidate.FinishReason.SAFETY) {
+                runContext.logger().warn("Content response has been blocked for safety reason");
+                output.blocked(true);
+            }
+            else if (finishReason == Candidate.FinishReason.RECITATION) {
+                runContext.logger().warn("Content response has been blocked for recitation reason");
+                output.blocked(true);
+            }
+            else {
+                output.text(ResponseHandler.getText(response));
+            }
+
+            return output.build();
+        }
+    }
+
+    private Part createPart(RunContext runContext, Content content) {
+        try (InputStream is = runContext.uriToInputStream(URI.create(runContext.render(content.getContent())))) {
+            byte[] partBytes = is.readAllBytes();
+            return PartMaker.fromMimeTypeAndData(content.mimeType, partBytes);
+        } catch (IllegalVariableEvaluationException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected MutableHttpRequest<?> getPredictionRequest(RunContext runContext) {
+        throw new UnsupportedOperationException("Generative AI task didn't use the request facility");
+    }
+
+    @SuperBuilder
+    @Value
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(
+            title = "The generated response text"
+        )
+        String text;
+
+        @Schema(
+            title = "The response safety ratings"
+        )
+        List<SafetyRating> safetyRatings;
+
+        @Schema(
+            title = "Whether the response has been blocked for safety reasons"
+        )
+        boolean blocked;
+
+        @Schema(
+            title = "The reason the generation has finished"
+        )
+        String finishReason;
+
+        @Override
+        public Optional<State.Type> finalState() {
+            return blocked ? Optional.of(State.Type.WARNING) : io.kestra.core.models.tasks.Output.super.finalState();
+        }
+    }
+
+    @Value
+    public static class Content {
+        @Schema(
+            title = "Mime type of the content, use it only when the content is not text"
+        )
+        @PluginProperty(dynamic = true)
+        String mimeType;
+
+        @Schema(
+            title = "The content itself, should be a string for text content or a Kestra internal storage URL for other content types.",
+            description = "If the content is not text, the `mimeType` property must be set."
+        )
+        @PluginProperty
+        @NotNull
+        String content;
+    }
+
+    @Value
+    public static class SafetyRating {
+        @Schema(
+            title = "Safety category"
+        )
+        String category;
+
+        @Schema(
+            title = "Safety rating probability"
+        )
+        String probability;
+
+        @Schema(
+            title = "Whether the response has been blocked for this safety reason"
+        )
+        boolean blocked;
+    }
+}

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/QueryTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/QueryTest.java
@@ -1,12 +1,8 @@
 package io.kestra.plugin.gcp.bigquery;
 
 import com.devskiller.friendly_id.FriendlyId;
-import com.google.cloud.bigquery.JobException;
 import com.google.cloud.bigquery.JobInfo;
-import com.google.common.collect.ContiguousSet;
-import com.google.common.collect.DiscreteDomain;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Range;
 import com.google.common.io.CharStreams;
 import io.micronaut.context.annotation.Value;
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest;
@@ -20,7 +16,6 @@ import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.storages.StorageInterface;
 import io.kestra.core.utils.TestsUtils;
 
-import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -28,6 +23,8 @@ import java.time.LocalTime;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import jakarta.inject.Inject;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -161,7 +158,7 @@ class QueryTest {
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of(
-            "loop", ContiguousSet.create(Range.closed(1, 25), DiscreteDomain.integers())
+            "loop", IntStream.range(1, 26).boxed().toList()
         ));
 
         Query.Output run = task.run(runContext);
@@ -203,7 +200,7 @@ class QueryTest {
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of(
-            "loop", ContiguousSet.create(Range.closed(1, 2), DiscreteDomain.integers())
+            "loop", IntStream.range(1, 3).boxed().toList()
         ));
 
         Query.Output run = task.run(runContext);
@@ -263,7 +260,7 @@ class QueryTest {
             .build();
 
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of(
-            "loop", ContiguousSet.create(Range.closed(1, 2), DiscreteDomain.integers())
+            "loop", IntStream.range(1, 3).boxed().toList()
         ));
 
         FailsafeException e = assertThrows(FailsafeException.class, () -> {


### PR DESCRIPTION
You can test with the following flow that will show how to make a multi-modal completion using Gemeni Generative AI.

```yaml
id: gemini-completion
namespace: dev

inputs:
  - name: image
    type: FILE
  - name: video
    type: FILE

tasks
  - id: ask-for-jokes
    type: io.kestra.plugin.gcp.vertexai.MultimodalCompletion
    region: <regionId>
    projectId: <projectId>
    contents:
      - content: Can you tell me a good joke?

  - id: describe-image
    type: io.kestra.plugin.gcp.vertexai.MultimodalCompletion
    region: <regionId>
    projectId: <projectId>
    contents:
      - content: Can you describe this image?
      - mimeType: image/jpeg
        content: "{{ inputs.image }}"

  - id: describe-video
    type: io.kestra.plugin.gcp.vertexai.MultimodalCompletion
    region: <regionId>
    projectId: <projectId>
    contents:
      - content: Can you describe this video?
      - mimeType: video/mpeg4
        content: "{{ inputs.video }}"
```

To trigger a blocked response, you can ask to describe a harmful image (like an identity card) or for a sarcastic joke.