### PR TITLE
Adjust docs to use MIB units as number instead of GB

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/runner/Batch.java
+++ b/src/main/java/io/kestra/plugin/gcp/runner/Batch.java
@@ -543,7 +543,7 @@ public class Batch extends TaskRunner implements GcpInterface, RemoteRunnerInter
 
         @Schema(
             title = "Memory in MiB.",
-            description = "Defines the amount of memory per task in MiB units. If undefined, the default value is `2GB`. " +
+            description = "Defines the amount of memory per task in MiB units. If undefined, the default value is `2048`. " +
                 "If you also define the VM's machine type using the `machineType` in " +
                 "[InstancePolicy](https://cloud.google.com/batch/docs/reference/rest/v1/projects.locations.jobs#instancepolicy) " +
                 "field or inside the `instanceTemplate` in the " +
@@ -552,8 +552,7 @@ public class Batch extends TaskRunner implements GcpInterface, RemoteRunnerInter
                 "tasks you want to allow to run on the same VM at the same time.\n" +
                 "\n" +
                 "For example, if you specify the `n2-standard-2` machine type, which has 8 GiB of memory, you can set " +
-                "the `memory` to no more than `8GB`. Alternatively, you can run two tasks on the same VM " +
-                "if you set the `memory` to `4GB` or less."
+                "the `memory` to no more than `8192`."
         )
         @PluginProperty
         private String memory;


### PR DESCRIPTION
<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->
- The `2GB` unit for example does not work, one needs to input `2048` as a string (MiB) and it works. Adjusted docs to say this.
- removed the 2 task reference in docs, since Kestra currently does not offer more than one task in GCP Batch job 

- *Note: I don't know if the default is correct in the documentation, as I couldn't find a default set in the code, but it might be a GCP default that is set. Basically this setting of ComputeResources Memory/CPU is required in order to use full power of Batch Runner's compute engine instance. This is because Kestra creates one task for the Compute Engine instance, and you use these settings to set it to use all resources.

---

### How the changes have been QAed?
- Ran it in my Kestra instance in 2 scenarios:
    1. default input parameter values for these settings set in workflow
    2. setting input parameter in a different flow that calls the subflow workflow

```yaml
  - id: cpu
    type: STRING
    defaults: "2000"
    description: Defines the amount of CPU resources used by the trask in milliCPU units.
  
  - id: memory
    type: STRING
    defaults: "4096"
    description: Defines the amount of memory used by the task in MiB units.
```

```yaml
    taskRunner:
      type: io.kestra.plugin.gcp.runner.Batch	
      projectId: "{{ secret('GCP_PROJECT_ID') }}"
      region: us-central1
      bucket: "{{ secret('GCS_LANDING_BUCKET') }}"
      waitUntilCompletion: 86400
      machineType: "{{ inputs.machine_type }}"
      serviceAccount: "{{ secret('GCP_SERVICE_ACCOUNT_JSON') }}"
      computeResource:
        cpu: "{{ inputs.cpu }}"
        memory: "{{ inputs.memory }}"
```