### PR TITLE
docs: fix typo in schema

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/gcs/ListInterface.java
+++ b/src/main/java/io/kestra/plugin/gcp/gcs/ListInterface.java
@@ -18,7 +18,7 @@ public interface ListInterface {
         description = "if DIRECTORY, will only list objects in the specified directory\n" +
             "if RECURSIVE, will list objects in the specified directory recursively\n" +
             "Default value is DIRECTORY\n" +
-            "When using RECURSIVE value, be carefull to move your files to a location not in the `from` scope"
+            "When using RECURSIVE value, be careful to move your files to a location not in the `from` scope"
     )
     @PluginProperty
     List.ListingType getListingType();


### PR DESCRIPTION
### What changes are being made and why?

Correcting the typos in the schema to satisfy the codespell check used in SchemaStore, see [https://github.com/kestra-io/kestra/issues/4653](https://github.com/kestra-io/kestra/issues/4653) for further details