### PR TITLE
fix: BigQuery Copy task didn't need store fetch valdation

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Copy.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Copy.java
@@ -51,8 +51,6 @@ import jakarta.validation.constraints.NotNull;
 @Schema(
     title = "Copy a BigQuery table or partition to other one."
 )
-@StoreFetchValidation
-@StoreFetchDestinationValidation
 public class Copy extends AbstractJob implements RunnableTask<Copy.Output> {
     @Schema(
         title = "The source tables.",


### PR DESCRIPTION
As it didn't have the fecth* property!

Fixes #428