### PR TITLE
Prevent job labels being overwritten for BigQuery

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Copy.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Copy.java
@@ -124,15 +124,16 @@ public class Copy extends AbstractJob implements RunnableTask<Copy.Output> {
             builder.setOperationType(runContext.render(this.operationType).as(OperationType.class).orElseThrow().name());
         }
 
-        if (this.labels != null) {
-            builder.setLabels(runContext.render(this.labels).asMap(String.class, String.class ));
-        }
-
         if (this.jobTimeout != null) {
             builder.setJobTimeoutMs(runContext.render(this.jobTimeout).as(Duration.class).orElseThrow().toMillis());
         }
 
-        builder.setLabels(BigQueryService.labels(runContext));
+        Map<String, String> finalLabels = new HashMap<>(BigQueryService.labels(runContext));
+        var renderedLabels = runContext.render(this.labels).asMap(String.class, String.class);
+        if (!renderedLabels.isEmpty()) {
+            finalLabels.putAll(renderedLabels);
+        }
+        builder.setLabels(finalLabels);
 
         return builder.build();
     }

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Copy.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Copy.java
@@ -17,7 +17,9 @@ import lombok.experimental.SuperBuilder;
 import org.slf4j.Logger;
 
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import jakarta.validation.constraints.NotNull;
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/ExtractToGcs.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/ExtractToGcs.java
@@ -225,13 +225,12 @@ public class ExtractToGcs extends AbstractBigquery implements RunnableTask<Extra
         }
 
         Map<String, String> finalLabels = new HashMap<>(BigQueryService.labels(runContext));
-        var renderedLbels = runContext.render(this.labels).asList(String.class);
-        if (!renderedLbels.isEmpty()) {
-            finalLabels.putAll(renderedLbels);
+        var renderedLabels = runContext.render(this.labels).asMap(String.class, String.class);
+        if (!renderedLabels.isEmpty()) {
+            finalLabels.putAll(renderedLabels);
         }
         builder.setLabels(finalLabels);
 
         return builder.build();
     }
 }
-

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
@@ -377,11 +377,6 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
             builder.setUseLegacySql(runContext.render(this.useLegacySql).as(Boolean.class).orElseThrow());
         }
 
-        var renderedLabels = runContext.render(this.labels).asMap(String.class, String.class);
-        if (!renderedLabels.isEmpty()) {
-            builder.setLabels(renderedLabels);
-        }
-
         if (this.jobTimeout != null) {
             builder.setJobTimeoutMs(runContext.render(this.jobTimeout).as(Duration.class).orElseThrow().toMillis());
         }
@@ -418,7 +413,12 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
             builder.setFlattenResults(runContext.render(this.flattenResults).as(Boolean.class).orElseThrow());
         }
 
-        builder.setLabels(BigQueryService.labels(runContext));
+        Map<String, String> finalLabels = new HashMap<>(BigQueryService.labels(runContext));
+        var renderedLabels = runContext.render(this.labels).asMap(String.class, String.class);
+        if (!renderedLabels.isEmpty()) {
+            finalLabels.putAll(renderedLabels);
+        }
+        builder.setLabels(finalLabels);
 
         return builder.build();
     }

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/QueryTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/QueryTest.java
@@ -359,4 +359,30 @@ class QueryTest {
 
         countDownLatch.await();
     }
+
+    @Test
+    void labelsAreNotOverwritten() throws Exception {
+        Map<String, String> initialLabels = new HashMap<>();
+        initialLabels.put("env", "test");
+        initialLabels.put("engine", "bigquery");
+
+        Query task = Query.builder()
+                .id("query")
+                .type(Query.class.getName())
+                .sql(Property.of("SELECT 1"))
+                .labels(Property.of(initialLabels))
+                .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        var labels = task.jobConfiguration(runContext).getLabels();
+
+        assertThat(labels.size(), is(6));
+        assertThat(labels.get("env"), is("test"));
+        assertThat(labels.get("engine"), is("bigquery"));
+        assertThat(labels.get("kestra_namespace"), is("io_kestra_plugin_gcp_bigquery_querytest"));
+        assertThat(labels.get("kestra_flow_id"), is("labelsarenotoverwritten"));
+        assertThat(labels.get("kestra_execution_id"), notNullValue());
+        assertThat(labels.get("kestra_task_id"), is("query"));
+    }
 }


### PR DESCRIPTION
### What changes are being made and why?
For BigQuery job labels ensure the two instances are merged, as currently two separate calls are being made to `builder.setLabels` which causes the user defined labels to be lost, this will close #482

I have made this change to both the `Copy` and `Query` tasks. In addition I have also corrected the type for the `ExtractToGCS` task

---

### How the changes have been QAed?

I ran this against a Google Cloud instance I have setup for Kestra development. It's using the `develop-no-plugins` docker image locally, below is the flow I used to test

```yaml
id: bigquery_labels
namespace: test

tasks:
  - id: labels
    type: io.kestra.plugin.gcp.bigquery.Query
    defaultDataset: demo
    labels:
      hello: world
      foo: bar
    sql: |
      SELECT * FROM users
    fetch: true
```
When running the above flow both the user defined and kestra labels are visible (see below)

![image](https://github.com/user-attachments/assets/711265a1-cda6-4f60-8c66-a47ede0471bc)