### PR TITLE
feat(#8080): implement kill method for vertex AI CustomJob task

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/vertexai/CustomJob.java
+++ b/src/main/java/io/kestra/plugin/gcp/vertexai/CustomJob.java
@@ -23,7 +23,6 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import org.slf4j.Logger;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;

--- a/src/main/java/io/kestra/plugin/gcp/vertexai/CustomJob.java
+++ b/src/main/java/io/kestra/plugin/gcp/vertexai/CustomJob.java
@@ -103,12 +103,12 @@ public class CustomJob extends AbstractTask implements RunnableTask<CustomJob.Ou
     @JsonIgnore
     @Getter(AccessLevel.NONE)
     @Builder.Default
-    private AtomicReference<Runnable> killable = new AtomicReference<>();
+    private final AtomicReference<Runnable> killable = new AtomicReference<>();
 
     @JsonIgnore
     @Getter(AccessLevel.NONE)
     @Builder.Default
-    private AtomicBoolean isKilled = new AtomicBoolean(false);
+    private final AtomicBoolean isKilled = new AtomicBoolean(false);
 
     @Override
     public Output run(RunContext runContext) throws Exception {
@@ -222,7 +222,7 @@ public class CustomJob extends AbstractTask implements RunnableTask<CustomJob.Ou
             runContext.logger().warn("API issue when cancelling job: {}", jobName);
             Thread.currentThread().interrupt();
         } catch (Exception e) {
-            runContext.logger().warn("Failed to delete Job: {}", jobName, e);
+            runContext.logger().warn("Failed to cancel job: {}", jobName, e);
         }
     }
 


### PR DESCRIPTION
Implement `kill` method from `WorkerJobLifecycle` class to allow deletion of the job when killing the task.
[#8080](https://github.com/kestra-io/kestra/issues/8080)