### PR TITLE
tests: fix repositoryLoader.load now requiring tenantId

### DIFF
--- a/src/test/java/io/kestra/plugin/gcp/bigquery/TriggerTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/TriggerTest.java
@@ -85,7 +85,7 @@ class TriggerTest {
             worker.run();
             scheduler.run();
 
-            repositoryLoader.load(Objects.requireNonNull(TriggerTest.class.getClassLoader().getResource("flows/bigquery")));
+            repositoryLoader.load(null, Objects.requireNonNull(TriggerTest.class.getClassLoader().getResource("flows/bigquery")));
 
             createTable.run(TestsUtils.mockRunContext(runContextFactory, createTable, ImmutableMap.of()));
 

--- a/src/test/java/io/kestra/plugin/gcp/gcs/TriggerTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/gcs/TriggerTest.java
@@ -93,7 +93,7 @@ class TriggerTest {
 
             worker.run();
             scheduler.run();
-            repositoryLoader.load(Objects.requireNonNull(TriggerTest.class.getClassLoader().getResource("flows/gcs")));
+            repositoryLoader.load(null, Objects.requireNonNull(TriggerTest.class.getClassLoader().getResource("flows/gcs")));
 
             boolean await = queueCount.await(10, TimeUnit.SECONDS);
             try {

--- a/src/test/java/io/kestra/plugin/gcp/pubsub/RealtimeTriggerTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/pubsub/RealtimeTriggerTest.java
@@ -78,7 +78,7 @@ class RealtimeTriggerTest {
             worker.run();
             scheduler.run();
 
-            repositoryLoader.load(Objects.requireNonNull(RealtimeTriggerTest.class.getClassLoader().getResource("flows/pubsub/realtime.yaml")));
+            repositoryLoader.load(null, Objects.requireNonNull(RealtimeTriggerTest.class.getClassLoader().getResource("flows/pubsub/realtime.yaml")));
 
             // publish message to trigger the flow
             Publish task = Publish.builder()

--- a/src/test/java/io/kestra/plugin/gcp/pubsub/TriggerTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/pubsub/TriggerTest.java
@@ -77,7 +77,7 @@ class TriggerTest {
             worker.run();
             scheduler.run();
 
-            repositoryLoader.load(Objects.requireNonNull(TriggerTest.class.getClassLoader().getResource("flows/pubsub/pubsub-listen.yaml")));
+            repositoryLoader.load(null, Objects.requireNonNull(TriggerTest.class.getClassLoader().getResource("flows/pubsub/pubsub-listen.yaml")));
 
             // publish two messages to trigger the flow
             Publish task = Publish.builder()


### PR DESCRIPTION
- recent core dev https://github.com/kestra-io/kestra/pull/8361 changed a test utility method signature