### PR TITLE
feat(gcs): support default listingType in Compose task

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/gcs/Compose.java
+++ b/src/main/java/io/kestra/plugin/gcp/gcs/Compose.java
@@ -89,7 +89,7 @@ public class Compose extends AbstractGcs implements RunnableTask<Compose.Output>
             .scopes(this.scopes)
             .from(this.list.getFrom())
             .filter(Property.of(ListInterface.Filter.FILES))
-            .listingType(this.list.getListingType())
+            .listingType(this.list.getListingType() != null ? this.list.getListingType() : Property.of(ListInterface.ListingType.DIRECTORY))
             .regExp(this.list.getRegExp())
             .build();
 

--- a/src/main/java/io/kestra/plugin/gcp/gcs/ListInterface.java
+++ b/src/main/java/io/kestra/plugin/gcp/gcs/ListInterface.java
@@ -1,6 +1,5 @@
 package io.kestra.plugin.gcp.gcs;
 
-import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/test/java/io/kestra/plugin/gcp/gcs/ComposeTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/gcs/ComposeTest.java
@@ -70,4 +70,40 @@ class ComposeTest {
         );
 
     }
+
+    @Test
+    void runWithDefaultListingType() throws Exception {
+        String dir = FriendlyId.createFriendlyId();
+        String basePath = "compose-" + dir + "/";
+
+        testUtils.upload(basePath + FriendlyId.createFriendlyId(), "data/1.txt");
+        testUtils.upload(basePath + FriendlyId.createFriendlyId(), "data/2.txt");
+        testUtils.upload(basePath + FriendlyId.createFriendlyId(), "data/3.txt");
+
+        Compose task = Compose.builder()
+            .id("compose-default-listingType")
+            .type(Compose.class.getName())
+            .list(Compose.List.builder()
+                .from(Property.of("gs://" + bucket + "/tasks/gcp/upload/" + basePath))
+                .build()
+            )
+            .to(Property.of("gs://" + bucket + "/tasks/gcp/compose-result/compose-default.txt"))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(this.runContextFactory, task, ImmutableMap.of());
+        Compose.Output run = task.run(runContext);
+
+        Download download = Download.builder()
+            .id(DownloadTest.class.getSimpleName())
+            .type(Download.class.getName())
+            .from(Property.of(run.getUri().toString()))
+            .build();
+
+        InputStream get = storageInterface.get(TenantService.MAIN_TENANT, null, download.run(runContext).getUri());
+
+        assertThat(
+            CharStreams.toString(new InputStreamReader(get)),
+            is("1\n2\n3\n")
+        );
+    }
 }


### PR DESCRIPTION
Adds default value for `listingType` when not provided as input.

fixes #506 