### PR TITLE
fix(bigquery): preserve microsecond precision for DATETIME when fetchType=STORE

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
@@ -629,7 +629,8 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
         }
 
         if (LegacySQLTypeName.DATETIME.equals(field.getType())) {
-            return Instant.parse(value.getStringValue() + "Z");
+            Instant.parse(value.getStringValue() + "Z");
+            return value.getStringValue() + "Z";
         }
 
         if (LegacySQLTypeName.FLOAT.equals(field.getType())) {

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/QueryTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/QueryTest.java
@@ -149,7 +149,7 @@ class QueryTest {
         String ionResult = CharStreams.toString(new InputStreamReader(storageInterface.get(TenantService.MAIN_TENANT, null, run.getUri())));
 
         assertThat(ionResult, containsString("string:\"hello\""));
-        assertThat(ionResult, containsString("datetime:2008-12-25T15:30:00.123Z"));
+        assertThat(ionResult, containsString("datetime:\"2008-12-25T15:30:00.123456Z\""));
         assertThat(ionResult, containsString("string:\"hello\""));
         assertThat(ionResult, containsString("interval:\"1-0 0 0:0:0\""));
     }


### PR DESCRIPTION
When using `fetchType: STORE`, `DATETIME`value was being truncated millisecond precision caused by`java.time.Instant` objects resulted in a lossy conversion.
fixes #495 
