### PR TITLE
feat: Added a field "force" to force delete existing blobs before deleting bucket

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/gcs/DeleteBucket.java
+++ b/src/main/java/io/kestra/plugin/gcp/gcs/DeleteBucket.java
@@ -2,18 +2,18 @@ package io.kestra.plugin.gcp.gcs;
 
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
-import io.kestra.core.models.property.Property;
-import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
-import lombok.experimental.SuperBuilder;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.runners.RunContext;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
 import org.slf4j.Logger;
 
 import java.net.URI;
-import jakarta.validation.constraints.NotNull;
 
 @SuperBuilder
 @ToString
@@ -53,6 +53,8 @@ public class DeleteBucket extends AbstractGcs implements RunnableTask<DeleteBuck
     @Builder.Default
     private Property<Boolean> force = Property.ofValue(false);
 
+    public static final int CONCURRENT_DELETIONS = 8;
+
     @Override
     public Output run(RunContext runContext) throws Exception {
         Storage connection = this.connection(runContext);
@@ -69,7 +71,7 @@ public class DeleteBucket extends AbstractGcs implements RunnableTask<DeleteBuck
                 .serviceAccount(this.serviceAccount)
                 .scopes(this.scopes)
                 .from(Property.ofValue("gs://" + name))
-                .concurrent(8)
+                .concurrent(CONCURRENT_DELETIONS)
                 .build();
 
             deleteListTask.run(runContext);

--- a/src/main/java/io/kestra/plugin/gcp/gcs/DeleteList.java
+++ b/src/main/java/io/kestra/plugin/gcp/gcs/DeleteList.java
@@ -75,7 +75,7 @@ public class DeleteList extends AbstractList implements RunnableTask<DeleteList.
 
     @Min(2)
     @Schema(
-        title = "Number of concurrent parallel deletions"
+        title = "Number of concurrent deletions"
     )
     @PluginProperty
     private Integer concurrent;

--- a/src/test/java/io/kestra/plugin/gcp/gcs/DeleteBucketTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/gcs/DeleteBucketTest.java
@@ -1,0 +1,118 @@
+package io.kestra.plugin.gcp.gcs;
+
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import com.google.common.collect.ImmutableMap;
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.TestsUtils;
+import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedConstruction;
+import org.mockito.Mockito;
+
+import java.net.URI;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@KestraTest
+class DeleteBucketTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Test
+    void forceFalse_shouldDeleteBucket() throws Exception {
+        // given
+        DeleteBucket task = Mockito.spy(DeleteBucket.builder()
+            .id(DeleteBucket.class.getSimpleName())
+            .type(DeleteBucket.class.getName())
+            .name(Property.ofValue("my-bucket"))
+            .force(Property.ofValue(false))
+            .build());
+
+        // Mock GCS Storage delete so no real bucket is touched.
+        Storage storage = mock(Storage.class);
+        doReturn(storage).when(task).connection(any(RunContext.class));
+        when(storage.delete("my-bucket")).thenReturn(true);
+
+        // Real (non-mocked) Kestra RunContext
+        var runContext = TestsUtils.mockRunContext(this.runContextFactory, task, ImmutableMap.of());
+
+        // when
+        DeleteBucket.Output output = task.run(runContext);
+
+        // then
+        verify(storage, times(1)).delete("my-bucket");
+        assertThat(output.getBucket(), is("my-bucket"));
+        assertThat(output.getBucketUri(), is(new URI("gs://my-bucket")));
+    }
+
+    @Test
+    void forceTrue_shouldCallDeleteListBeforeDeletingBucket() throws Exception {
+        // given
+        DeleteBucket task = Mockito.spy(DeleteBucket.builder()
+            .id(DeleteBucket.class.getSimpleName())
+            .type(DeleteBucket.class.getName())
+            .name(Property.ofValue("my-bucket"))
+            .force(Property.ofValue(true))
+            .build());
+
+        Storage storage = mock(Storage.class);
+        doReturn(storage).when(task).connection(any(RunContext.class));
+        when(storage.delete("my-bucket")).thenReturn(true);
+
+        var runContext = TestsUtils.mockRunContext(this.runContextFactory, task, ImmutableMap.of());
+
+        // Intercept DeleteList construction so we don't delete anything real.
+        try (MockedConstruction<DeleteList> mocked = Mockito.mockConstruction(
+            DeleteList.class,
+            (mock, context) -> {
+                when(mock.run(any(RunContext.class)))
+                    .thenReturn(DeleteList.Output.builder().count(0).size(0).build());
+            }
+        )) {
+            // when
+            DeleteBucket.Output output = task.run(runContext);
+
+            // then: DeleteList constructed once and executed once
+            assertThat(mocked.constructed().size(), is(1));
+            verify(mocked.constructed().getFirst(), times(1)).run(runContext);
+
+            // and: bucket delete executed
+            verify(storage, times(1)).delete("my-bucket");
+
+            // and: output ok
+            assertThat(output.getBucket(), is("my-bucket"));
+            assertThat(output.getBucketUri(), is(new URI("gs://my-bucket")));
+        }
+    }
+
+    @Test
+    void shouldThrow404WhenBucketNotFound() throws Exception {
+        // given
+        DeleteBucket task = Mockito.spy(DeleteBucket.builder()
+            .id(DeleteBucket.class.getSimpleName())
+            .type(DeleteBucket.class.getName())
+            .name(Property.ofValue("missing-bucket"))
+            .force(Property.ofValue(false))
+            .build());
+
+        Storage storage = mock(Storage.class);
+        doReturn(storage).when(task).connection(any(RunContext.class));
+        when(storage.delete("missing-bucket")).thenReturn(false);
+
+        var runContext = TestsUtils.mockRunContext(this.runContextFactory, task, ImmutableMap.of());
+
+        // when / then
+        StorageException ex = assertThrows(StorageException.class, () -> task.run(runContext));
+        assertThat(ex.getCode(), is(404));
+        assertThat(ex.getMessage(), containsString("Couldn't find bucket 'missing-bucket'"));
+    }
+}


### PR DESCRIPTION
Closes #321 

### What changes are being made and why?
Reused the existing DeleteList task to clear all blobs under the bucket with uri `gs://<bucket-name>` prior to deletion of the bucket.

### How the changes have been QAed?

Used the following flow to create and upload files in the test-bucket 
```yaml
id: gcs-plugin
namespace: company.team

tasks:
  - id: create-bucket
    type: io.kestra.plugin.gcp.gcs.CreateBucket
    projectId: "gcs-testing"
    name: "test-bucket"
    ifExists: SKIP

  - id: data
    type: io.kestra.plugin.core.http.Download
    uri: https://huggingface.co/datasets/kestra/datasets/raw/main/csv/orders.csv

    
  - id: for-each-upload
    type: io.kestra.plugin.core.flow.ForEach
    values: [1, 2, 3, 4, 5, 6]
    tasks:
      - id: upload-files
        type: io.kestra.plugin.gcp.gcs.Upload
        projectId: "gcs-testing"
        from: "{{ outputs.data[\"uri\"] }}"
        to: "gs://test-bucket/data{{taskrun.value}}.csv"
```
Then used the following flow to delete bucket 
```yaml
id: delete-bucket
namespace: company.team

tasks:
  - id: del-gcs-bucket
    type: io.kestra.plugin.gcp.gcs.DeleteBucket
    name: "test-bucket"
    projectId: "gcs-testing"
    force: true
```

Attaching test screenshots

The delete fails without force 

<img width="965" height="485" alt="Screenshot from 2025-10-22 00-03-23" src="https://github.com/user-attachments/assets/e0265b15-743f-44a6-b02a-cc4159221b5b" />

The delete bucket completes when force is set as true

<img width="965" height="485" alt="Screenshot from 2025-10-21 23-40-05" src="https://github.com/user-attachments/assets/740dcbe7-2193-45c4-9e3e-bb157c5fd404" />

---

### Setup Instructions

Used an emulator gcs server using docker `docker run   --name fake-gcp   --network kestra_default   -p 4443:4443   fsouza/fake-gcs-server   -scheme http -d` OR 
you can use an actual google cloud storage account. 

---

### Contributor Checklist ✅

- [X] PR Title and commits follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Add a `closes #ISSUE_ID` or `fixes #ISSUE_ID` in the description if the PR relates to an opened issue.
- [X] Documentation updated (plugin docs from `@Schema` for properties and outputs, `@Plugin` with examples, `README.md` file with basic knowledge and specifics).
- [X] Setup instructions included if needed (API keys, accounts, etc.).
- [ X] Prefix all rendered properties by `r` not `rendered` (eg: `rHost`).
- [ ] Use `runContext.logger()` to log enough important infos where it's needed and with the best level (DEBUG, INFO, WARN or ERROR).

⚙️ **Properties**
- [X] Properties are declared with `Property<T>` carrier type, do **not** use `@PluginProperty`.
- [ ] Mandatory properties must be annotated with `@NotNull` and checked during the rendering.
- [ ] You can model a JSON thanks to a simple `Property<Map<String, Object>>`.

🌐 **HTTP**
- [ ] Must use Kestra’s internal HTTP client from `io.kestra.core.http.client`

📦 **JSON**
- [ ] If you are serializing response from an external API, you may have to add a `@JsonIgnoreProperties(ignoreUnknown = true)` at the mapped class level. So that we will avoid to crash the plugin if the provider add a new field suddenly.
- [ ] Must use Jackson mappers provided by core (`io.kestra.core.serializers`)

✨ **New plugins / subplugins**
- [ ] Make sure your new plugin is configured like mentioned [here](https://kestra.io/docs/plugin-developer-guide/gradle#mandatory-configuration).
- [ ] Add a `package-info.java` under each sub package respecting [this format](https://github.com/kestra-io/plugin-odoo/blob/main/src/main/java/io/kestra/plugin/odoo/package-info.java) and choosing the right category.
- [ ] Icons added in `src/main/resources/icons` in SVG format and not in thumbnail (keep it big):
  - `plugin-icon.svg`
  - One icon per package, e.g. `io.kestra.plugin.aws.svg`
  - For subpackages, e.g. `io.kestra.plugin.aws.s3`, add `io.kestra.plugin.aws.s3.svg`
    See example [here](https://github.com/kestra-io/plugin-elasticsearch/blob/master/src/main/java/io/kestra/plugin/elasticsearch/Search.java#L76).
- [ ] Use `"{{ secret('YOUR_SECRET') }}"` in the examples for sensible infos such as an API KEY.
- [ ] If you are fetching data (one, many or too many), you must add a `Property<FetchType> fetchType` to be able to use `FETCH_ONE`, `FETCH` and even `STORE` to store big amount of data in the internal storage.
- [ ] Align the `"""` to close examples blocks with the flow id.

🧪 **Tests**
- [ ] Unit Tests added or updated to cover the change (using the `RunContext` to actually run tasks).
- [ ] Add sanity checks if possible with a YAML flow inside `src/test/resources/flows`.
- [ ] Avoid disabling tests for CI. Instead, configure a local environment whenever it's possible with `.github/setup-unit.sh` (which can be executed locally and in the CI) all along with a new `docker-compose-ci.yml` file (do **not** edit the existing `docker-compose.yml`).
- [X] Provide screenshots from your QA / tests locally in the PR description. The goal here is to use the JAR of the plugin and directly test it locally in Kestra UI to ensure it integrates well.

📤 **Outputs**
- [ ] Do not send back as outputs the same infos you already have in your properties.
- [ ] If you do not have any output use `VoidOutput`.
- [ ] Do not output twice the same infos (eg: a status code, an error code saying the same thing...).
