### PR TITLE
Refactor: Replace @Slf4j with runContext.logger() in plugin tests

### DIFF
--- a/src/test/java/io/kestra/plugin/gcp/bigquery/CopyTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/CopyTest.java
@@ -2,14 +2,13 @@ package io.kestra.plugin.gcp.bigquery;
 
 import com.devskiller.friendly_id.FriendlyId;
 import com.google.common.collect.ImmutableMap;
+import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.utils.TestsUtils;
 import io.micronaut.context.annotation.Value;
-import io.kestra.core.junit.annotations.KestraTest;
 import jakarta.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
@@ -21,7 +20,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @KestraTest
-@Slf4j
 class CopyTest {
     @Inject
     private RunContextFactory runContextFactory;

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/CreateUpdateTableTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/CreateUpdateTableTest.java
@@ -1,8 +1,9 @@
 package io.kestra.plugin.gcp.bigquery;
 
 import com.devskiller.friendly_id.FriendlyId;
-import com.google.cloud.bigquery.*;
+import com.google.cloud.bigquery.StandardSQLTypeName;
 import com.google.common.collect.ImmutableMap;
+import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
@@ -11,20 +12,16 @@ import io.kestra.plugin.gcp.bigquery.models.Schema;
 import io.kestra.plugin.gcp.bigquery.models.StandardTableDefinition;
 import io.kestra.plugin.gcp.bigquery.models.TableDefinition;
 import io.micronaut.context.annotation.Value;
-import io.kestra.core.junit.annotations.KestraTest;
-import lombok.extern.slf4j.Slf4j;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
 import java.util.Arrays;
-import jakarta.inject.Inject;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
-@Slf4j
 class CreateUpdateTableTest {
     @Inject
     private RunContextFactory runContextFactory;

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/QueryTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/QueryTest.java
@@ -40,7 +40,6 @@ import static org.hamcrest.Matchers.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
-@Slf4j
 class QueryTest {
     @Inject
     private RunContextFactory runContextFactory;
@@ -279,7 +278,7 @@ class QueryTest {
                 try {
                     return outputFuture.get();
                 } catch (InterruptedException | ExecutionException e) {
-                    log.error("Failed on ", e);
+                    runContextFactory.of().logger().error("Failed on ", e);
                     return null;
                 }
             })

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/TableMetadataTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/TableMetadataTest.java
@@ -3,18 +3,15 @@ package io.kestra.plugin.gcp.bigquery;
 import com.devskiller.friendly_id.FriendlyId;
 import com.google.cloud.bigquery.*;
 import com.google.common.collect.ImmutableMap;
-import io.kestra.core.models.property.Property;
-import io.micronaut.context.annotation.Value;
 import io.kestra.core.junit.annotations.KestraTest;
-import lombok.extern.slf4j.Slf4j;
-import org.junit.jupiter.api.Test;
+import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
-
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import io.micronaut.context.annotation.Value;
 import jakarta.inject.Inject;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -22,7 +19,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @KestraTest
-@Slf4j
 class TableMetadataTest {
     @Inject
     private RunContextFactory runContextFactory;

--- a/src/test/java/io/kestra/plugin/gcp/dataproc/batches/PySparkSubmitTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/dataproc/batches/PySparkSubmitTest.java
@@ -1,14 +1,13 @@
 package io.kestra.plugin.gcp.dataproc.batches;
 
 import com.google.common.collect.ImmutableMap;
+import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.utils.TestsUtils;
 import io.micronaut.context.annotation.Value;
-import io.kestra.core.junit.annotations.KestraTest;
 import jakarta.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +16,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @KestraTest
-@Slf4j
 @Disabled
 class PySparkSubmitTest {
     @Inject

--- a/src/test/java/io/kestra/plugin/gcp/dataproc/batches/RSparkSubmitTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/dataproc/batches/RSparkSubmitTest.java
@@ -1,14 +1,13 @@
 package io.kestra.plugin.gcp.dataproc.batches;
 
 import com.google.common.collect.ImmutableMap;
+import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.utils.TestsUtils;
 import io.micronaut.context.annotation.Value;
-import io.kestra.core.junit.annotations.KestraTest;
 import jakarta.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +16,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @KestraTest
-@Slf4j
 @Disabled
 class RSparkSubmitTest {
     @Inject

--- a/src/test/java/io/kestra/plugin/gcp/dataproc/batches/SparkSqlSubmitTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/dataproc/batches/SparkSqlSubmitTest.java
@@ -1,14 +1,13 @@
 package io.kestra.plugin.gcp.dataproc.batches;
 
 import com.google.common.collect.ImmutableMap;
+import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.utils.TestsUtils;
 import io.micronaut.context.annotation.Value;
-import io.kestra.core.junit.annotations.KestraTest;
 import jakarta.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -17,7 +16,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @KestraTest
-@Slf4j
 @Disabled
 class SparkSqlSubmitTest {
     @Inject

--- a/src/test/java/io/kestra/plugin/gcp/dataproc/batches/SparkSubmitTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/dataproc/batches/SparkSubmitTest.java
@@ -1,14 +1,13 @@
 package io.kestra.plugin.gcp.dataproc.batches;
 
 import com.google.common.collect.ImmutableMap;
+import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.utils.TestsUtils;
 import io.micronaut.context.annotation.Value;
-import io.kestra.core.junit.annotations.KestraTest;
 import jakarta.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +18,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @KestraTest
-@Slf4j
 @Disabled
 class SparkSubmitTest {
     @Inject

--- a/src/test/java/io/kestra/plugin/gcp/dataproc/clusters/CreateTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/dataproc/clusters/CreateTest.java
@@ -8,7 +8,6 @@ import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.utils.TestsUtils;
 import io.micronaut.context.annotation.Value;
 import jakarta.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -16,7 +15,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 @KestraTest
-@Slf4j
 @Disabled
 public class CreateTest {
 

--- a/src/test/java/io/kestra/plugin/gcp/dataproc/clusters/DeleteTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/dataproc/clusters/DeleteTest.java
@@ -8,16 +8,13 @@ import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.utils.TestsUtils;
 import io.micronaut.context.annotation.Value;
 import jakarta.inject.Inject;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
 
 @KestraTest
-@Slf4j
 @Disabled
 public class DeleteTest {
 


### PR DESCRIPTION
This PR replaces `@Slf4j` with `runContext.logger()` to align with project logging conventions.

Refs: kestra-io/kestra#12770

**Changes**:
- Removed unused `@Slf4j` annotations from test classes
- Replaced `runContext.logger()` instead of `@Slf4j`

<img width="701" height="306" alt="Screenshot 2025-11-07 at 11 55 50 PM" src="https://github.com/user-attachments/assets/40064821-50c0-4c3d-961d-8e22492c9181" />


**Verification:**

✅ Project-wide search confirms zero remaining usages of `@Slf4j`  (see screenshot)
✅ Code compiles successfully with no errors or warnings
✅ No functional changes - test behaviour is identical