### PR TITLE
fix(bigquery): replace unbounded Flux BUFFER with Flux.fromStream in Query.storeResult

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
@@ -46,7 +46,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.FluxSink;
 import reactor.core.publisher.Mono;
 
 @SuperBuilder
@@ -661,21 +660,10 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
         try (
             var output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)
         ) {
-            Flux<Object> flowable = Flux
-                .create(
-                    s ->
-                    {
-                        StreamSupport
-                            .stream(result.iterateAll().spliterator(), false)
-                            .forEach(fieldValues ->
-                            {
-                                s.next(this.convertRows(result, fieldValues));
-                            });
-
-                        s.complete();
-                    },
-                    FluxSink.OverflowStrategy.BUFFER
-                );
+            Flux<Object> flowable = Flux.fromStream(
+                StreamSupport.stream(result.iterateAll().spliterator(), false)
+                    .map(fieldValues -> (Object) this.convertRows(result, fieldValues))
+            );
             Mono<Long> longMono = FileSerde.writeAll(output, flowable);
 
             // metrics & finalize


### PR DESCRIPTION
Fix https://github.com/kestra-io/plugin-gcp/issues/604

## Root cause

`Query.storeResult` used `Flux.create(..., FluxSink.OverflowStrategy.BUFFER)` to drive `FileSerde.writeAll`:

```java
Flux<Object> flowable = Flux.create(
    s -> {
        StreamSupport.stream(result.iterateAll().spliterator(), false)
            .forEach(fv -> s.next(this.convertRows(result, fv)));
        s.complete();
    },
    FluxSink.OverflowStrategy.BUFFER
);
```

`Flux.create` is **push-based**: the producer (`forEach`) runs synchronously to completion before the subscriber drains, pumping every converted row into Reactor's internal unbounded queue. `iterateAll()` pages lazily from BigQuery, but that backpressure is invisible to Reactor here — every fetched row gets materialised as a `LinkedHashMap` and queued in JVM heap before any byte hits disk.

Customer had two parallel tasks:
- 19,681 rows × 12 cols (some `REPEATED STRING`) → 75.5 MiB ION → ~4 KB/row in memory
- 3,324 rows × 10 cols (same) → 60.1 MiB ION → ~18 KB/row in memory

With N parallel executions, heap spiked to ~2.5 GiB (visible in Grafana) and triggered an OOM kill at ~01:00 CEST on 2026-04-27.

## Fix

Replace `Flux.create(..., BUFFER)` with `Flux.fromStream`, which is **pull-based** (synchronous-fuseable source). Reactor's `writeAll` chain pulls one row at a time via `doOnNext`, so only one `LinkedHashMap` is live during each write cycle:

```java
Flux<Object> flowable = Flux.fromStream(
    StreamSupport.stream(result.iterateAll().spliterator(), false)
        .map(fieldValues -> (Object) this.convertRows(result, fieldValues))
);
Mono<Long> longMono = FileSerde.writeAll(output, flowable);
```

This matches the pattern already used in `firestore/Query.java` (`Flux.fromIterable` + `FileSerde.writeAll`).

The `FluxSink` import is removed as it is no longer referenced.

## Out of scope

`fetchResult` (used by `FETCH` / `FETCH_ONE`) also collects to a `List` — same memory class of issue, separate follow-up.