### PR TITLE
feat: add checksum validation for upload

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/gcs/Upload.java
+++ b/src/main/java/io/kestra/plugin/gcp/gcs/Upload.java
@@ -3,10 +3,16 @@ package io.kestra.plugin.gcp.gcs;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.zip.CRC32C;
 
 import org.slf4j.Logger;
 
 import com.google.cloud.WriteChannel;
+import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
@@ -120,6 +126,28 @@ public class Upload extends AbstractGcs implements RunnableTask<Upload.Output> {
     @PluginProperty(group = "advanced")
     private Property<String> cacheControl;
 
+    @Schema(
+        title = "Validate checksum after upload",
+        description = "When true (default), compute MD5 and CRC32C client-side while streaming and compare them against what GCS reports server-side once the upload completes. When false, the implicit transit integrity check is skipped; explicit `expectedMd5`/`expectedCrc32c` assertions are still honored when set."
+    )
+    @PluginProperty(group = "reliability")
+    @Builder.Default
+    private Property<Boolean> validateChecksum = Property.ofValue(true);
+
+    @Schema(
+        title = "Expected MD5 of the source",
+        description = "Optional base64-encoded MD5 digest. When set, the task fails if the source data read from Kestra internal storage does not match this digest. Use this to assert end-to-end integrity against a checksum produced upstream."
+    )
+    @PluginProperty(group = "reliability")
+    private Property<String> expectedMd5;
+
+    @Schema(
+        title = "Expected CRC32C of the source",
+        description = "Optional base64-encoded big-endian CRC32C. When set, the task fails if the source data read from Kestra internal storage does not match this checksum."
+    )
+    @PluginProperty(group = "reliability")
+    private Property<String> expectedCrc32c;
+
     @Override
     public Output run(RunContext runContext) throws Exception {
         Storage connection = this.connection(runContext);
@@ -154,17 +182,69 @@ public class Upload extends AbstractGcs implements RunnableTask<Upload.Output> {
 
         BlobInfo destination = builder.build();
 
+        boolean rValidateChecksum = runContext.render(this.validateChecksum).as(Boolean.class).orElse(true);
+        String rExpectedMd5 = runContext.render(this.expectedMd5).as(String.class).orElse(null);
+        String rExpectedCrc32c = runContext.render(this.expectedCrc32c).as(String.class).orElse(null);
+        boolean computeLocally = rValidateChecksum || rExpectedMd5 != null || rExpectedCrc32c != null;
+
         logger.debug("Upload from '{}' to '{}'", from, to);
 
-        try (InputStream data = runContext.storage().getFile(from)) {
+        MessageDigest md5Digest = computeLocally ? MessageDigest.getInstance("MD5") : null;
+        CRC32C crc32c = computeLocally ? new CRC32C() : null;
+
+        try (InputStream rawData = runContext.storage().getFile(from);
+             InputStream data = computeLocally ? new DigestInputStream(rawData, md5Digest) : rawData) {
             long size = 0;
             try (WriteChannel writer = connection.writer(destination)) {
                 byte[] buffer = new byte[10_240];
 
                 int limit;
                 while ((limit = data.read(buffer)) >= 0) {
+                    if (computeLocally) {
+                        crc32c.update(buffer, 0, limit);
+                    }
                     writer.write(ByteBuffer.wrap(buffer, 0, limit));
                     size += limit;
+                }
+            }
+
+            String computedMd5 = null;
+            String computedCrc32c = null;
+            if (computeLocally) {
+                computedMd5 = Base64.getEncoder().encodeToString(md5Digest.digest());
+                computedCrc32c = Base64.getEncoder().encodeToString(
+                    ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt((int) crc32c.getValue()).array()
+                );
+
+                if (rExpectedMd5 != null && !rExpectedMd5.equals(computedMd5)) {
+                    throw new IllegalStateException(
+                        "Source MD5 mismatch: expected=" + rExpectedMd5 + ", computed=" + computedMd5
+                    );
+                }
+                if (rExpectedCrc32c != null && !rExpectedCrc32c.equals(computedCrc32c)) {
+                    throw new IllegalStateException(
+                        "Source CRC32C mismatch: expected=" + rExpectedCrc32c + ", computed=" + computedCrc32c
+                    );
+                }
+
+                if (rValidateChecksum) {
+                    Blob uploaded = connection.get(destination.getBlobId());
+                    if (uploaded == null) {
+                        throw new IllegalStateException("Uploaded blob not found for integrity check: " + destination.getBlobId());
+                    }
+
+                    if (!computedMd5.equals(uploaded.getMd5())) {
+                        throw new IllegalStateException(
+                            "MD5 mismatch between client and GCS: client=" + computedMd5 + ", gcs=" + uploaded.getMd5()
+                        );
+                    }
+                    if (!computedCrc32c.equals(uploaded.getCrc32c())) {
+                        throw new IllegalStateException(
+                            "CRC32C mismatch between client and GCS: client=" + computedCrc32c + ", gcs=" + uploaded.getCrc32c()
+                        );
+                    }
+
+                    logger.debug("Upload integrity verified (md5={}, crc32c={})", computedMd5, computedCrc32c);
                 }
             }
 
@@ -173,6 +253,8 @@ public class Upload extends AbstractGcs implements RunnableTask<Upload.Output> {
             return Output
                 .builder()
                 .uri(new URI("gs://" + destination.getBucket() + "/" + encode(destination.getName())))
+                .md5(computedMd5)
+                .crc32c(computedCrc32c)
                 .build();
         }
     }
@@ -180,6 +262,13 @@ public class Upload extends AbstractGcs implements RunnableTask<Upload.Output> {
     @Builder
     @Getter
     public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(title = "Uploaded object URI")
         private URI uri;
+
+        @Schema(title = "Base64-encoded MD5 of the uploaded data")
+        private String md5;
+
+        @Schema(title = "Base64-encoded big-endian CRC32C of the uploaded data")
+        private String crc32c;
     }
 }

--- a/src/main/java/io/kestra/plugin/gcp/gcs/Upload.java
+++ b/src/main/java/io/kestra/plugin/gcp/gcs/Upload.java
@@ -216,36 +216,16 @@ public class Upload extends AbstractGcs implements RunnableTask<Upload.Output> {
                     ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt((int) crc32c.getValue()).array()
                 );
 
-                if (rExpectedMd5 != null && !rExpectedMd5.equals(computedMd5)) {
-                    throw new IllegalStateException(
-                        "Source MD5 mismatch: expected=" + rExpectedMd5 + ", computed=" + computedMd5
-                    );
-                }
-                if (rExpectedCrc32c != null && !rExpectedCrc32c.equals(computedCrc32c)) {
-                    throw new IllegalStateException(
-                        "Source CRC32C mismatch: expected=" + rExpectedCrc32c + ", computed=" + computedCrc32c
-                    );
-                }
-
-                if (rValidateChecksum) {
-                    Blob uploaded = connection.get(destination.getBlobId());
-                    if (uploaded == null) {
-                        throw new IllegalStateException("Uploaded blob not found for integrity check: " + destination.getBlobId());
-                    }
-
-                    if (!computedMd5.equals(uploaded.getMd5())) {
-                        throw new IllegalStateException(
-                            "MD5 mismatch between client and GCS: client=" + computedMd5 + ", gcs=" + uploaded.getMd5()
-                        );
-                    }
-                    if (!computedCrc32c.equals(uploaded.getCrc32c())) {
-                        throw new IllegalStateException(
-                            "CRC32C mismatch between client and GCS: client=" + computedCrc32c + ", gcs=" + uploaded.getCrc32c()
-                        );
-                    }
-
-                    logger.debug("Upload integrity verified (md5={}, crc32c={})", computedMd5, computedCrc32c);
-                }
+                verifyChecksums(
+                    computedMd5,
+                    computedCrc32c,
+                    rExpectedMd5,
+                    rExpectedCrc32c,
+                    rValidateChecksum,
+                    connection,
+                    destination.getBlobId(),
+                    logger
+                );
             }
 
             runContext.metric(Counter.of("file.size", size));
@@ -256,6 +236,48 @@ public class Upload extends AbstractGcs implements RunnableTask<Upload.Output> {
                 .md5(computedMd5)
                 .crc32c(computedCrc32c)
                 .build();
+        }
+    }
+
+    private void verifyChecksums(
+        String computedMd5,
+        String computedCrc32c,
+        String rExpectedMd5,
+        String rExpectedCrc32c,
+        boolean rValidateChecksum,
+        Storage connection,
+        BlobId blobId,
+        Logger logger
+    ) {
+        if (rExpectedMd5 != null && !rExpectedMd5.equals(computedMd5)) {
+            throw new IllegalStateException(
+                "Source MD5 mismatch: expected=" + rExpectedMd5 + ", computed=" + computedMd5
+            );
+        }
+        if (rExpectedCrc32c != null && !rExpectedCrc32c.equals(computedCrc32c)) {
+            throw new IllegalStateException(
+                "Source CRC32C mismatch: expected=" + rExpectedCrc32c + ", computed=" + computedCrc32c
+            );
+        }
+
+        if (rValidateChecksum) {
+            Blob uploaded = connection.get(blobId);
+            if (uploaded == null) {
+                throw new IllegalStateException("Uploaded blob not found for integrity check: " + blobId);
+            }
+
+            if (!computedMd5.equals(uploaded.getMd5())) {
+                throw new IllegalStateException(
+                    "MD5 mismatch between client and GCS: client=" + computedMd5 + ", gcs=" + uploaded.getMd5()
+                );
+            }
+            if (!computedCrc32c.equals(uploaded.getCrc32c())) {
+                throw new IllegalStateException(
+                    "CRC32C mismatch between client and GCS: client=" + computedCrc32c + ", gcs=" + uploaded.getCrc32c()
+                );
+            }
+
+            logger.debug("Upload integrity verified (md5={}, crc32c={})", computedMd5, computedCrc32c);
         }
     }
 

--- a/src/test/java/io/kestra/plugin/gcp/gcs/UploadChecksumTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/gcs/UploadChecksumTest.java
@@ -1,0 +1,133 @@
+package io.kestra.plugin.gcp.gcs;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Base64;
+import java.util.zip.CRC32C;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+
+import com.devskiller.friendly_id.FriendlyId;
+import com.google.common.collect.ImmutableMap;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.tenant.TenantService;
+import io.kestra.core.utils.TestsUtils;
+
+import io.micronaut.context.annotation.Value;
+import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@KestraTest
+@EnabledIfEnvironmentVariable(named = "GOOGLE_APPLICATION_CREDENTIALS", matches = ".+")
+class UploadChecksumTest {
+    @Inject
+    private StorageInterface storageInterface;
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Value("${kestra.tasks.gcs.bucket}")
+    private String bucket;
+
+    @Test
+    void defaultValidationPopulatesOutputChecksums() throws Exception {
+        byte[] content = ("kestra-" + FriendlyId.createFriendlyId()).getBytes(StandardCharsets.UTF_8);
+        Upload task = uploadOf(content).build();
+
+        Upload.Output run = task.run(mockRunContext(task));
+
+        assertThat(run.getUri(), notNullValue());
+        assertThat(run.getMd5(), equalTo(md5Base64(content)));
+        assertThat(run.getCrc32c(), equalTo(crc32cBase64(content)));
+    }
+
+    @Test
+    void disablingValidationSkipsChecksumComputation() throws Exception {
+        byte[] content = "no-checksum".getBytes(StandardCharsets.UTF_8);
+        Upload task = uploadOf(content)
+            .validateChecksum(Property.ofValue(false))
+            .build();
+
+        Upload.Output run = task.run(mockRunContext(task));
+
+        assertThat(run.getUri(), notNullValue());
+        assertThat(run.getMd5(), nullValue());
+        assertThat(run.getCrc32c(), nullValue());
+    }
+
+    @Test
+    void expectedMd5StillEnforcedWhenValidationDisabled() throws Exception {
+        byte[] content = "explicit-assertion".getBytes(StandardCharsets.UTF_8);
+        Upload task = uploadOf(content)
+            .validateChecksum(Property.ofValue(false))
+            .expectedMd5(Property.ofValue(md5Base64(content)))
+            .build();
+
+        Upload.Output run = task.run(mockRunContext(task));
+
+        assertThat(run.getMd5(), equalTo(md5Base64(content)));
+    }
+
+    @Test
+    void expectedMd5MismatchThrowsBeforeServerCheck() throws Exception {
+        byte[] content = "mismatch".getBytes(StandardCharsets.UTF_8);
+        Upload task = uploadOf(content)
+            .expectedMd5(Property.ofValue("AAAAAAAAAAAAAAAAAAAAAA=="))
+            .build();
+        RunContext rc = mockRunContext(task);
+
+        IllegalStateException ex = assertThrows(IllegalStateException.class, () -> task.run(rc));
+        assertThat(ex.getMessage(), containsString("Source MD5 mismatch"));
+    }
+
+    private Upload.UploadBuilder<?, ?> uploadOf(byte[] content) throws Exception {
+        URI source = storageInterface.put(
+            TenantService.MAIN_TENANT,
+            null,
+            new URI("/" + FriendlyId.createFriendlyId()),
+            new ByteArrayInputStream(content)
+        );
+
+        return Upload.builder()
+            .id(UploadChecksumTest.class.getSimpleName())
+            .type(Upload.class.getName())
+            .from(Property.ofValue(source.toString()))
+            .to(Property.ofValue("gs://{{inputs.bucket}}/tasks/gcp/upload-checksum/" + FriendlyId.createFriendlyId() + ".bin"));
+    }
+
+    private RunContext mockRunContext(Upload task) {
+        return TestsUtils.mockRunContext(
+            runContextFactory,
+            task,
+            ImmutableMap.of("bucket", bucket)
+        );
+    }
+
+    private static String md5Base64(byte[] content) throws Exception {
+        return Base64.getEncoder().encodeToString(MessageDigest.getInstance("MD5").digest(content));
+    }
+
+    private static String crc32cBase64(byte[] content) {
+        CRC32C crc = new CRC32C();
+        crc.update(content);
+        return Base64.getEncoder().encodeToString(
+            ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN).putInt((int) crc.getValue()).array()
+        );
+    }
+}


### PR DESCRIPTION
relates https://github.com/kestra-io/kestra-ee/issues/5699


### QA

Flows used :

``` yaml
id: gcp_gcs_download
namespace: company.team

inputs:
  - id: file
    type: FILE
tasks:
  - id: upload
    type: io.kestra.plugin.gcp.gcs.Upload
    from: "{{ inputs.file }}"
    to: "gs://TRUNCATED.txt"
    validateChecksum: true
    expectedCrc32c: "75ZmaQ=="
```


``` yaml
id: gcp_gcs_download
namespace: company.team

inputs:
  - id: file
    type: FILE
tasks:
  - id: upload
    type: io.kestra.plugin.gcp.gcs.Upload
    from: "{{ inputs.file }}"
    to: "gs://TRUNCATED.txt"
    validateChecksum: true
    expectedMd5: "wrong"
```

Tested with good/wrong MD5, good/wrong Crc32c.

<img width="2172" height="390" alt="image" src="https://github.com/user-attachments/assets/f327ae23-fe74-4f87-9a58-b97fa6af8476" />

<img width="2172" height="390" alt="image" src="https://github.com/user-attachments/assets/f00e0d66-d411-4e20-948b-3a66cf945a17" />


<img width="2172" height="390" alt="image" src="https://github.com/user-attachments/assets/4d973254-6b57-4b8d-8c87-e736454d39f3" />

