### PR TITLE
fix(core): migrate FileSerde to InputStream/OutputStream API for binary ION support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 version=2.4.1-SNAPSHOT
-kestraVersion=1.3.13
+kestraVersion=1.3.19
 org.gradle.jvmargs=-Xmx4g

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
@@ -658,7 +658,7 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
         File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
 
         try (
-            var output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)
+            var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)
         ) {
             Flux<Object> flowable = Flux.fromStream(
                 StreamSupport.stream(result.iterateAll().spliterator(), false)

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/StorageWrite.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/StorageWrite.java
@@ -1,8 +1,8 @@
 package io.kestra.plugin.gcp.bigquery;
 
-import java.io.BufferedReader;
+import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.InputStream;
 import java.net.URI;
 import java.time.*;
 import java.time.format.DateTimeFormatter;
@@ -136,7 +136,7 @@ public class StorageWrite extends AbstractTask implements RunnableTask<StorageWr
 
         try (
             BigQueryWriteClient connection = this.connection(runContext);
-            BufferedReader inputStream = new BufferedReader(new InputStreamReader(runContext.storage().getFile(from)), FileSerde.BUFFER_SIZE)
+            InputStream inputStream = new BufferedInputStream(runContext.storage().getFile(from), FileSerde.BUFFER_SIZE)
         ) {
             try (JsonStreamWriter writer = this.jsonStreamWriter(runContext, parentTable, connection).build()) {
                 Integer count = FileSerde.readAll(inputStream)

--- a/src/main/java/io/kestra/plugin/gcp/firestore/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/firestore/Query.java
@@ -239,7 +239,7 @@ public class Query extends AbstractFirestore implements RunnableTask<FetchOutput
     private Pair<URI, Long> store(RunContext runContext, List<QueryDocumentSnapshot> documents) throws IOException {
         File tempFile = runContext.workingDir().createTempFile(".ion").toFile();
 
-        try (var output = new BufferedWriter(new FileWriter(tempFile), FileSerde.BUFFER_SIZE)) {
+        try (var output = new BufferedOutputStream(new FileOutputStream(tempFile), FileSerde.BUFFER_SIZE)) {
             Flux<Map<String, Object>> flux = Flux.fromIterable(documents).map(snapshot -> snapshot.getData());
             Long count = FileSerde.writeAll(output, flux).block();
 


### PR DESCRIPTION
Migrates the FileSerde reads and writes to byte streams so binary ION is not corrupted.