### PR TITLE
fix(gcs): default Trigger/Downloads action to NONE

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/gcs/Downloads.java
+++ b/src/main/java/io/kestra/plugin/gcp/gcs/Downloads.java
@@ -104,9 +104,10 @@ public class Downloads extends AbstractGcs implements RunnableTask<Downloads.Out
 
     @Schema(
         title = "Post-download action",
-        description = "DELETE or MOVE (copy to moveDirectory then delete source)"
+        description = "NONE (default), DELETE, or MOVE (copy to moveDirectory then delete source)"
     )
-    private Property<ActionInterface.Action> action;
+    @Builder.Default
+    private final Property<ActionInterface.Action> action = Property.ofValue(ActionInterface.Action.NONE);
 
     @Schema(
         title = "Move destination",

--- a/src/main/java/io/kestra/plugin/gcp/gcs/Trigger.java
+++ b/src/main/java/io/kestra/plugin/gcp/gcs/Trigger.java
@@ -120,7 +120,8 @@ public class Trigger extends AbstractTrigger implements PollingTriggerInterface,
         title = "Post-detection action",
         description = "NONE (default), MOVE (requires moveDirectory), or DELETE on source objects after download"
     )
-    private Property<ActionInterface.Action> action;
+    @Builder.Default
+    private final Property<ActionInterface.Action> action = Property.ofValue(ActionInterface.Action.NONE);
 
     @Schema(
         title = "Move destination",

--- a/src/test/java/io/kestra/plugin/gcp/gcs/TriggerTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/gcs/TriggerTest.java
@@ -159,6 +159,41 @@ class TriggerTest {
     }
 
     @Test
+    void shouldFireWhenActionNotConfigured() throws Exception {
+        // Regression test for Pylon #1888: when no `action` is set, evaluating a trigger
+        // that detects files must not fail with "No value present" (NoSuchElementException).
+        String base = "trigger/no-action/" + IdUtils.create() + "/";
+        String file = base + FriendlyId.createFriendlyId();
+
+        Trigger trigger = Trigger.builder()
+            .id(TriggerTest.class.getSimpleName() + IdUtils.create())
+            .type(Trigger.class.getName())
+            .from(Property.ofValue("gs://" + bucket + "/tasks/gcp/upload/" + base))
+            .on(Property.ofValue(StatefulTriggerInterface.On.CREATE))
+            .build();
+
+        Upload.Output upload = testUtils.upload(file);
+
+        Map.Entry<ConditionContext, io.kestra.core.models.triggers.Trigger> context = TestsUtils.mockTrigger(runContextFactory, trigger);
+        Optional<Execution> execution = Assertions.assertDoesNotThrow(
+            () -> trigger.evaluate(context.getKey(), context.getValue())
+        );
+
+        assertThat(execution.isPresent(), is(true));
+
+        @SuppressWarnings("unchecked")
+        java.util.List<Blob> urls = (java.util.List<Blob>) execution.get().getTrigger().getVariables().get("blobs");
+        assertThat(urls.size(), is(1));
+
+        Delete delete = Delete.builder()
+            .id(DownloadTest.class.getSimpleName())
+            .type(Download.class.getName())
+            .uri(Property.ofValue(upload.getUri().toString()))
+            .build();
+        delete.run(TestsUtils.mockRunContext(runContextFactory, delete, ImmutableMap.of()));
+    }
+
+    @Test
     void shouldExecuteOnCreate() throws Exception {
         String base = "trigger/on-create/" + IdUtils.create() + "/";
         String file = base + FriendlyId.createFriendlyId();


### PR DESCRIPTION
## Root cause

`io.kestra.plugin.gcp.gcs.Trigger` and `io.kestra.plugin.gcp.gcs.Downloads` both call:

```java
runContext.render(action).as(Action.class).orElseThrow()
```

but their `action` property had **no default value**. When a flow did not configure `action`, the render produced an empty `Optional` and `.orElseThrow()` threw `NoSuchElementException` with the message `No value present`.

For the **Trigger**, this code path is only reached *after* the empty-result guard (`toFire.isEmpty()`), i.e. once new/updated files have actually been detected. So the trigger failed at the exact moment it was supposed to fire, with a worker log like:

```
WARN  Trigger evaluation failed in the worker with error: No value present
ERROR No value present
```

The `@Schema` description already documented `NONE` as the default ("NONE (default), MOVE, or DELETE"), so the behavior was a code/doc mismatch rather than an intended requirement.

## Fix

- Default `action` to `Action.NONE` (via `@Builder.Default`, matching the existing convention for `interval`/`listingType`/`scopes`) in both `Trigger` and `Downloads`.
- Update the `Downloads` schema description to mention `NONE (default)`.
- Add a regression test `TriggerTest#shouldFireWhenActionNotConfigured` that builds a `Trigger` with no `action`, detects an uploaded file, and asserts evaluation does not throw and fires with the blob present.

## Impact

This is reported by a production user (upgrade to 0.22) who had to work around it by switching to the deprecated `gcs.LegacyTrigger` with an explicit `action: NONE`. This fix lets them use `gcs.Trigger` without setting `action`, enabling migration off the legacy implementation.

## Testing

- `compileJava` / `compileTestJava` pass.
- The new and existing trigger tests require live GCP credentials (`@EnabledIfEnvironmentVariable("GOOGLE_APPLICATION_CREDENTIALS")`) and a configured bucket, so they run in CI rather than locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)