### PR TITLE
fix(build): increase npm install retry count to reduce ECONNRESET flakiness in CI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -276,7 +276,7 @@ idea {
 // Build the UI module before packaging (only if ui/ directory exists)
 if (file('ui').exists()) {
     tasks.register('npmInstallUI', com.github.gradle.node.npm.task.NpmTask) {
-        args = ['install']
+        args = ['install', '--fetch-retries=5', '--fetch-retry-mintimeout=5000', '--fetch-retry-maxtimeout=60000']
         workingDir = file('ui')
     }
 


### PR DESCRIPTION
## Summary

- Bumps `--fetch-retries` from npm's default (2) to 5 on the `npmInstallUI` Gradle task
- Adds explicit min/max timeout flags to give transient network resets time to recover
- Mirrors the same fix applied to `plugin-ai` after an `ECONNRESET` flake in CI

## Test plan

- [ ] CI passes on this branch