### PR TITLE
chore(deps): bump gradle plugins, spanner, and gradle wrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 plugins {
-    id 'io.kestra.gradle.repository-conventions' version '1.2.3'
+    id 'io.kestra.gradle.repository-conventions' version '1.2.5'
     id "io.kestra.gradle.plugin-doc-lint" version "1.2.5"
-    id 'io.kestra.gradle.spotless-conventions' version '1.2.2'
+    id 'io.kestra.gradle.spotless-conventions' version '1.2.5'
     id "com.vanniktech.maven.publish" version "0.37.0"
     id "io.kestra.gradle.inject-bom-versions" version "1.1.0"
     id 'java-library'
     id "idea"
     id 'jacoco'
     id "com.adarshr.test-logger" version "4.0.0"
-    id "com.gradleup.shadow" version "9.4.2"
+    id "com.gradleup.shadow" version "9.4.3"
     id 'signing'
     id "com.github.ben-manes.versions" version "0.54.0"
     id 'net.researchgate.release' version '3.1.0'
@@ -81,7 +81,7 @@ dependencies {
     api 'com.google.cloud:google-cloud-bigquery'
     api 'com.google.cloud:google-cloud-bigquerystorage'
     api 'com.google.cloud:google-cloud-bigtable:2.44.0'
-    api 'com.google.cloud:google-cloud-spanner:6.67.0'
+    api 'com.google.cloud:google-cloud-spanner:6.118.0'
     api 'com.google.cloud:google-cloud-container'
     api 'com.google.cloud:google-cloud-aiplatform'
     api 'com.google.cloud:google-cloud-logging'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0
 retryBackOffMs=500


### PR DESCRIPTION
Combines all open dependabot dependency PRs into one.

- com.gradleup.shadow 9.4.2 → 9.4.3 (closes #646)
- io.kestra.gradle.spotless-conventions 1.2.2 → 1.2.5 (closes #645)
- com.google.cloud:google-cloud-spanner 6.67.0 → 6.118.0 (closes #644)
- io.kestra.gradle.repository-conventions 1.2.3 → 1.2.5 (closes #643)
- gradle-wrapper 9.6.0 → 9.6.1 (closes #642)