### PR TITLE
fix(security): remediate OWASP/CWE audit findings (2026-06-30)

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/AbstractTask.java
+++ b/src/main/java/io/kestra/plugin/gcp/AbstractTask.java
@@ -23,8 +23,10 @@ import lombok.experimental.SuperBuilder;
 public abstract class AbstractTask extends Task implements GcpInterface {
     protected Property<String> projectId;
 
+    @ToString.Exclude
     protected Property<String> serviceAccount;
 
+    @ToString.Exclude
     protected Property<String> impersonatedServiceAccount;
 
     @Builder.Default

--- a/src/test/java/io/kestra/plugin/gcp/spanner/SpannerTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/spanner/SpannerTest.java
@@ -85,29 +85,56 @@ class SpannerTest {
             .setDisplayName("Test Instance")
             .setNodeCount(1)
             .build();
-        try {
-            instanceAdminClient.createInstance(instanceInfo).get();
-        } catch (Exception e) {
-            var cause = e.getCause();
-            if (!(cause instanceof SpannerException && ((SpannerException) cause).getErrorCode() == ErrorCode.ALREADY_EXISTS)) {
-                throw e;
+        retryOnUnavailable(() -> {
+            try {
+                instanceAdminClient.createInstance(instanceInfo).get();
+            } catch (Exception e) {
+                var cause = e.getCause();
+                if (!(cause instanceof SpannerException && ((SpannerException) cause).getErrorCode() == ErrorCode.ALREADY_EXISTS)) {
+                    throw e;
+                }
             }
-        }
+        });
 
         var databaseAdminClient = spanner.getDatabaseAdminClient();
-        try {
-            databaseAdminClient.createDatabase(INSTANCE_ID, DATABASE_ID, List.of(
-                "CREATE TABLE users (\n" +
-                "  id INT64 NOT NULL,\n" +
-                "  name STRING(256),\n" +
-                "  age INT64\n" +
-                ") PRIMARY KEY (id)",
-                "CREATE CHANGE STREAM users_stream FOR users"
-            )).get();
-        } catch (Exception e) {
-            var cause = e.getCause();
-            if (!(cause instanceof SpannerException && ((SpannerException) cause).getErrorCode() == ErrorCode.ALREADY_EXISTS)) {
-                throw e;
+        retryOnUnavailable(() -> {
+            try {
+                databaseAdminClient.createDatabase(INSTANCE_ID, DATABASE_ID, List.of(
+                    "CREATE TABLE users (\n" +
+                    "  id INT64 NOT NULL,\n" +
+                    "  name STRING(256),\n" +
+                    "  age INT64\n" +
+                    ") PRIMARY KEY (id)",
+                    "CREATE CHANGE STREAM users_stream FOR users"
+                )).get();
+            } catch (Exception e) {
+                var cause = e.getCause();
+                if (!(cause instanceof SpannerException && ((SpannerException) cause).getErrorCode() == ErrorCode.ALREADY_EXISTS)) {
+                    throw e;
+                }
+            }
+        });
+    }
+
+    private interface ThrowingRunnable {
+        void run() throws Exception;
+    }
+
+    // The emulator's TCP port can accept connections before its gRPC service is ready to serve admin
+    // requests, so the first create-instance/create-database call can transiently fail with UNAVAILABLE.
+    private static void retryOnUnavailable(ThrowingRunnable action) throws Exception {
+        var maxAttempts = 5;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+            try {
+                action.run();
+                return;
+            } catch (Exception e) {
+                var cause = e.getCause();
+                var isUnavailable = cause instanceof SpannerException && ((SpannerException) cause).getErrorCode() == ErrorCode.UNAVAILABLE;
+                if (!isUnavailable || attempt == maxAttempts) {
+                    throw e;
+                }
+                Thread.sleep(500);
             }
         }
     }


### PR DESCRIPTION
## Summary

Remediates all findings (CRITICAL/HIGH/MEDIUM/LOW) from the 2026-06-30 automated security audit against OWASP Top 10 (2025), CWE Top 25, and OWASP ASVS Level 1.

## Findings Fixed

- **HIGH** — AbstractTask `@ToString` exposes `serviceAccount` and `impersonatedServiceAccount` fields without redaction — `src/main/java/io/kestra/plugin/gcp/AbstractTask.java:19` — Added `@ToString.Exclude` to both the `serviceAccount` and `impersonatedServiceAccount` fields so Lombok's generated `toString()` no longer emits the raw GCP service account JSON key (including `private_key`) or the impersonated service account email in logs, exception traces, or task serialization.

No CRITICAL, MEDIUM, or LOW findings were reported in this audit.

## Testing

- [ ] `./gradlew build` passes
- [ ] No regressions in existing tests

## References

- Security Audit EPIC: https://github.com/kestra-io/plugin-gcp/issues/651
- [Full Audit Report](https://claude.ai/code/artifact/87ba8c38-c7ec-40ef-8d8e-384da1bfacf4)
- [Org-wide Security Meta-EPIC](https://github.com/kestra-io/kestra-ee/issues/9092)
