### PR TITLE
fix(bigquery): avoid duplicate job submission on transient retry

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
@@ -102,7 +102,7 @@ abstract public class AbstractBigquery extends AbstractTask {
     }
 
     protected Job waitForJob(Logger logger, Callable<Job> createJob, Boolean dryRun, RunContext runContext, BigQuery connection) {
-        AtomicReference<JobId> lastJobId = new AtomicReference<>();
+        var lastJobId = new AtomicReference<JobId>();
 
         return Failsafe
             .with(
@@ -138,22 +138,27 @@ abstract public class AbstractBigquery extends AbstractTask {
             {
                 Job job = null;
                 try {
-                    JobId previousJobId = lastJobId.get();
-                    if (previousJobId != null) {
-                        Job previousJob = connection.getJob(previousJobId);
+                    // Dry-run jobs have no side effects and aren't reliably pollable, so always create a fresh one.
+                    if (!dryRun) {
+                        var previousJobId = lastJobId.get();
+                        if (previousJobId != null) {
+                            var previousJob = connection.getJob(previousJobId);
 
-                        if (previousJob != null) {
-                            if (!previousJob.isDone()) {
-                                previousJob = previousJob.waitFor();
-                            }
+                            if (previousJob != null) {
+                                if (!previousJob.isDone()) {
+                                    previousJob = previousJob.waitFor();
+                                }
 
-                            if (previousJob.getStatus().getError() == null) {
-                                logger.warn(
-                                    "Job '{}' already completed successfully despite a transient error, skipping duplicate retry",
-                                    previousJob.getJobId()
-                                );
+                                if (previousJob.getStatus().getError() == null) {
+                                    logger.warn(
+                                        "Job '{}' already completed successfully despite a transient error, skipping duplicate retry",
+                                        previousJob.getJobId()
+                                    );
 
-                                return previousJob;
+                                    return previousJob;
+                                }
+
+                                lastJobId.set(null);
                             }
                         }
                     }

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 
@@ -96,11 +97,13 @@ abstract public class AbstractBigquery extends AbstractTask {
             .getService();
     }
 
-    protected Job waitForJob(Logger logger, Callable<Job> createJob, RunContext runContext) {
-        return this.waitForJob(logger, createJob, false, runContext);
+    protected Job waitForJob(Logger logger, Callable<Job> createJob, RunContext runContext, BigQuery connection) {
+        return this.waitForJob(logger, createJob, false, runContext, connection);
     }
 
-    protected Job waitForJob(Logger logger, Callable<Job> createJob, Boolean dryRun, RunContext runContext) {
+    protected Job waitForJob(Logger logger, Callable<Job> createJob, Boolean dryRun, RunContext runContext, BigQuery connection) {
+        AtomicReference<JobId> lastJobId = new AtomicReference<>();
+
         return Failsafe
             .with(
                 AbstractRetry.<Job> retryPolicy(
@@ -135,7 +138,28 @@ abstract public class AbstractBigquery extends AbstractTask {
             {
                 Job job = null;
                 try {
+                    JobId previousJobId = lastJobId.get();
+                    if (previousJobId != null) {
+                        Job previousJob = connection.getJob(previousJobId);
+
+                        if (previousJob != null) {
+                            if (!previousJob.isDone()) {
+                                previousJob = previousJob.waitFor();
+                            }
+
+                            if (previousJob.getStatus().getError() == null) {
+                                logger.warn(
+                                    "Job '{}' already completed successfully despite a transient error, skipping duplicate retry",
+                                    previousJob.getJobId()
+                                );
+
+                                return previousJob;
+                            }
+                        }
+                    }
+
                     job = createJob.call();
+                    lastJobId.set(job.getJobId());
 
                     BigQueryService.handleErrors(job, logger);
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Copy.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Copy.java
@@ -100,7 +100,8 @@ public class Copy extends AbstractJob implements RunnableTask<Copy.Output> {
                         .build()
                 ),
             runContext.render(this.dryRun).as(Boolean.class).orElseThrow(),
-            runContext
+            runContext,
+            connection
         );
 
         JobStatistics.CopyStatistics copyJobStatistics = copyJob.getStatistics();

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Load.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Load.java
@@ -120,7 +120,7 @@ public class Load extends AbstractLoad implements RunnableTask<AbstractLoad.Outp
                     .build();
             }
 
-            Job job = this.waitForJob(logger, writer::getJob, runContext);
+            Job job = this.waitForJob(logger, writer::getJob, runContext, connection);
 
             return this.outputs(runContext, configuration, job);
         }

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/LoadFromGcs.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/LoadFromGcs.java
@@ -153,7 +153,7 @@ public class LoadFromGcs extends AbstractLoad implements RunnableTask<AbstractLo
                 JobInfo.newBuilder(configuration)
                     .setJobId(BigQueryService.jobId(runContext, this))
                     .build()
-            ), runContext
+            ), runContext, connection
         );
 
         return this.outputs(runContext, configuration, loadJob);

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
@@ -316,7 +316,8 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
                         .build()
                 ),
             runContext.render(this.dryRun).as(Boolean.class).orElseThrow(),
-            runContext
+            runContext,
+            connection
         );
         JobStatistics.QueryStatistics queryJobStatistics = queryJob.getStatistics();
 

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/QueryErrorTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/QueryErrorTest.java
@@ -334,7 +334,6 @@ public class QueryErrorTest {
         try {
             output = task.run(runContext);
         } catch (Exception e) {
-            getAllServeEvents().forEach(ev -> System.out.println("REQ: " + ev.getRequest().getMethod() + " " + ev.getRequest().getUrl() + " -> " + ev.getResponse().getStatus()));
             throw e;
         }
 

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/QueryErrorTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/QueryErrorTest.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.gcp.bigquery;
 
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.github.tomakehurst.wiremock.stubbing.Scenario;
 import com.google.cloud.NoCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
@@ -85,7 +86,8 @@ public class QueryErrorTest {
           "status": { "state": "RUNNING" },
           "statistics": {
             "creationTime": "1697123456789",
-            "startTime": "1697123457000"
+            "startTime": "1697123457000",
+            "query": { "statementType": "SELECT" }
           }
         }""";
 
@@ -112,6 +114,70 @@ public class QueryErrorTest {
             "startTime": "1697123457000",
             "endTime": "1697123459000",
             "query": { "statementType": "SELECT" }
+          }
+        }""";
+
+    private static final String JOB_RESPONSE_DUP_TEST_DONE_WITH_ERROR = """
+        {
+          "kind": "bigquery#job",
+          "etag": "\\"abcdef1234567890\\"",
+          "id": "kestra-unit-test:europe-west3.job_dup_test",
+          "jobReference": {
+            "projectId": "kestra-unit-test",
+            "jobId": "job_dup_test",
+            "location": "europe-west3"
+          },
+          "configuration": {
+            "query": {
+              "query": "SELECT * FROM `kestra-unit-test.my_dataset.my_table`",
+              "useLegacySql": false
+            },
+            "jobType": "QUERY"
+          },
+          "status": {
+            "state": "DONE",
+            "errorResult": {
+              "reason": "backendError",
+              "message": "Backend error while processing the job"
+            }
+          },
+          "statistics": {
+            "creationTime": "1697123456789",
+            "startTime": "1697123457000",
+            "endTime": "1697123459000",
+            "query": { "statementType": "SELECT" }
+          }
+        }""";
+
+    // Job#waitFor() polls the /queries/{jobId} endpoint, which returns a GetQueryResultsResponse,
+    // not a Job resource: it needs "jobComplete" to be seen as done, unlike the /jobs/{jobId} shapes above.
+    private static final String QUERY_RESULTS_RESPONSE_COMPLETE = """
+        {
+          "kind": "bigquery#getQueryResultsResponse",
+          "etag": "\\"abcdef1234567890\\"",
+          "jobReference": {
+            "projectId": "kestra-unit-test",
+            "jobId": "job_dup_test",
+            "location": "europe-west3"
+          },
+          "totalRows": "0",
+          "jobComplete": true,
+          "cacheHit": false
+        }""";
+
+    private static final String JOB_NOT_FOUND_RESPONSE = """
+        {
+          "error": {
+            "code": 404,
+            "errors": [
+              {
+                "domain": "global",
+                "message": "Not found: Job kestra-unit-test:europe-west3.job_dup_test",
+                "reason": "notFound"
+              }
+            ],
+            "message": "Not found: Job kestra-unit-test:europe-west3.job_dup_test",
+            "status": "NOT_FOUND"
           }
         }""";
 
@@ -223,6 +289,217 @@ public class QueryErrorTest {
         verify(1, postRequestedFor(urlPathMatching(jobsPath)));
     }
 
+    @Test
+    void shouldNotDuplicateJobWhenPreviousJobStillRunning(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String jobsPath = "/bigquery/v2/projects/.*/jobs";
+        String pollingPath = "/bigquery/v2/projects/.*/queries/job_dup_test.*";
+        String jobStatusPath = "/bigquery/v2/projects/.*/jobs/job_dup_test.*";
+
+        stubFor(post(urlPathMatching(jobsPath))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JOB_RESPONSE_RUNNING)));
+
+        // The job's own first poll fails transiently; once the retry looks the job up directly and
+        // finds it still running, it calls waitFor() again, which this time observes completion.
+        stubFor(get(urlPathMatching(pollingPath))
+            .inScenario("still-running")
+            .whenScenarioStateIs(Scenario.STARTED)
+            .willReturn(aResponse()
+                .withStatus(503)
+                .withHeader("Content-Type", "application/json")
+                .withBody(BACKEND_ERROR_RESPONSE))
+            .willSetStateTo("completed"));
+
+        stubFor(get(urlPathMatching(pollingPath))
+            .inScenario("still-running")
+            .whenScenarioStateIs("completed")
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(QUERY_RESULTS_RESPONSE_COMPLETE)));
+
+        // The job's real status, fetched directly, shows it is still running.
+        stubFor(get(urlPathMatching(jobStatusPath))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JOB_RESPONSE_RUNNING)));
+
+        Query task = buildQueryWithoutFetch(wmRuntimeInfo, 3);
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        Query.Output output;
+        try {
+            output = task.run(runContext);
+        } catch (Exception e) {
+            getAllServeEvents().forEach(ev -> System.out.println("REQ: " + ev.getRequest().getMethod() + " " + ev.getRequest().getUrl() + " -> " + ev.getResponse().getStatus()));
+            throw e;
+        }
+
+        assertEquals("job_dup_test", output.getJobId());
+        verify(1, postRequestedFor(urlPathMatching(jobsPath)));
+    }
+
+    @Test
+    void shouldCreateNewJobWhenPreviousJobDoneWithError(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String jobsPath = "/bigquery/v2/projects/.*/jobs";
+        String pollingPath = "/bigquery/v2/projects/.*/queries/job_dup_test.*";
+        String jobStatusPath = "/bigquery/v2/projects/.*/jobs/job_dup_test.*";
+
+        stubFor(post(urlPathMatching(jobsPath))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JOB_RESPONSE_RUNNING)));
+
+        // The original job's poll fails transiently; the fresh job submitted after the lookback
+        // then polls successfully.
+        stubFor(get(urlPathMatching(pollingPath))
+            .inScenario("done-with-error")
+            .whenScenarioStateIs(Scenario.STARTED)
+            .willReturn(aResponse()
+                .withStatus(503)
+                .withHeader("Content-Type", "application/json")
+                .withBody(BACKEND_ERROR_RESPONSE))
+            .willSetStateTo("completed"));
+
+        stubFor(get(urlPathMatching(pollingPath))
+            .inScenario("done-with-error")
+            .whenScenarioStateIs("completed")
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(QUERY_RESULTS_RESPONSE_COMPLETE)));
+
+        // The job's real status, fetched directly, shows it actually failed: no dedup, a new job is submitted.
+        // Job#waitFor() itself calls reload() (another GET on this same path) once the fresh job completes,
+        // to fetch its authoritative final status, so the stub must distinguish that call from the lookback.
+        stubFor(get(urlPathMatching(jobStatusPath))
+            .inScenario("done-with-error-status")
+            .whenScenarioStateIs(Scenario.STARTED)
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JOB_RESPONSE_DUP_TEST_DONE_WITH_ERROR))
+            .willSetStateTo("new-job-completed"));
+
+        stubFor(get(urlPathMatching(jobStatusPath))
+            .inScenario("done-with-error-status")
+            .whenScenarioStateIs("new-job-completed")
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JOB_RESPONSE_DUP_TEST_DONE)));
+
+        Query task = buildQueryWithoutFetch(wmRuntimeInfo, 3);
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        Query.Output output = task.run(runContext);
+
+        assertEquals("job_dup_test", output.getJobId());
+        verify(2, postRequestedFor(urlPathMatching(jobsPath)));
+    }
+
+    @Test
+    void shouldCreateNewJobWhenPreviousJobNotFound(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String jobsPath = "/bigquery/v2/projects/.*/jobs";
+        String pollingPath = "/bigquery/v2/projects/.*/queries/job_dup_test.*";
+        String jobStatusPath = "/bigquery/v2/projects/.*/jobs/job_dup_test.*";
+
+        stubFor(post(urlPathMatching(jobsPath))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JOB_RESPONSE_RUNNING)));
+
+        // The original job's poll fails transiently; the fresh job submitted after the lookback
+        // then polls successfully.
+        stubFor(get(urlPathMatching(pollingPath))
+            .inScenario("not-found")
+            .whenScenarioStateIs(Scenario.STARTED)
+            .willReturn(aResponse()
+                .withStatus(503)
+                .withHeader("Content-Type", "application/json")
+                .withBody(BACKEND_ERROR_RESPONSE))
+            .willSetStateTo("completed"));
+
+        stubFor(get(urlPathMatching(pollingPath))
+            .inScenario("not-found")
+            .whenScenarioStateIs("completed")
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(QUERY_RESULTS_RESPONSE_COMPLETE)));
+
+        // The job can no longer be found: no dedup, a new job is submitted.
+        // Job#waitFor() itself calls reload() (another GET on this same path) once the fresh job completes,
+        // to fetch its authoritative final status, so the stub must distinguish that call from the lookback.
+        stubFor(get(urlPathMatching(jobStatusPath))
+            .inScenario("not-found-status")
+            .whenScenarioStateIs(Scenario.STARTED)
+            .willReturn(aResponse()
+                .withStatus(404)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JOB_NOT_FOUND_RESPONSE))
+            .willSetStateTo("new-job-completed"));
+
+        stubFor(get(urlPathMatching(jobStatusPath))
+            .inScenario("not-found-status")
+            .whenScenarioStateIs("new-job-completed")
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JOB_RESPONSE_DUP_TEST_DONE)));
+
+        Query task = buildQueryWithoutFetch(wmRuntimeInfo, 3);
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        Query.Output output = task.run(runContext);
+
+        assertEquals("job_dup_test", output.getJobId());
+        verify(2, postRequestedFor(urlPathMatching(jobsPath)));
+    }
+
+    @Test
+    void shouldSkipLookbackOnDryRunRetry(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String jobsPath = "/bigquery/v2/projects/.*/jobs";
+        String pollingPath = "/bigquery/v2/projects/.*/queries/job_dup_test.*";
+        String jobStatusPath = "/bigquery/v2/projects/.*/jobs/job_dup_test.*";
+
+        // A dry-run job is never polled, so its first submission fails with a job-level error that
+        // is only visible once the job comes back as DONE; the retry submits a fresh dry-run job.
+        stubFor(post(urlPathMatching(jobsPath))
+            .inScenario("dry-run-retry")
+            .whenScenarioStateIs(Scenario.STARTED)
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JOB_RESPONSE_DUP_TEST_DONE_WITH_ERROR))
+            .willSetStateTo("completed"));
+
+        stubFor(post(urlPathMatching(jobsPath))
+            .inScenario("dry-run-retry")
+            .whenScenarioStateIs("completed")
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JOB_RESPONSE_DUP_TEST_DONE)));
+
+        Query task = buildDryRunQuery(wmRuntimeInfo, 3);
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        Query.Output output = task.run(runContext);
+
+        assertEquals("job_dup_test", output.getJobId());
+        verify(2, postRequestedFor(urlPathMatching(jobsPath)));
+        // The dryRun guard must skip the lookback entirely: no lookup of the previous job's status,
+        // and no polling, since Job#isDone()/#waitFor() aren't reliable for dry-run jobs.
+        verify(0, getRequestedFor(urlPathMatching(jobStatusPath)));
+        verify(0, getRequestedFor(urlPathMatching(pollingPath)));
+    }
+
     private Query buildQueryWithoutFetch(WireMockRuntimeInfo wmRuntimeInfo, int maxAttempts) throws Exception {
         Query task = Query.builder()
             .id(QueryTest.class.getSimpleName())
@@ -237,6 +514,28 @@ public class QueryErrorTest {
             .projectId(Property.ofValue(project))
             .sql(Property.ofValue("SELECT * from test_table"))
             .dryRun(Property.ofValue(false))
+            .build();
+
+        Query spy = Mockito.spy(task);
+        Mockito.doReturn(mockBigQueryClient(wmRuntimeInfo.getHttpBaseUrl()))
+            .when(spy).connection(Mockito.any(RunContext.class));
+        return spy;
+    }
+
+    private Query buildDryRunQuery(WireMockRuntimeInfo wmRuntimeInfo, int maxAttempts) throws Exception {
+        Query task = Query.builder()
+            .id(QueryTest.class.getSimpleName())
+            .type(Query.class.getName())
+            .retryAuto(Exponential.builder()
+                .type("exponential")
+                .interval(Duration.ofMillis(100))
+                .maxInterval(Duration.ofMillis(500))
+                .maxDuration(Duration.ofSeconds(10))
+                .maxAttempts(maxAttempts)
+                .build())
+            .projectId(Property.ofValue(project))
+            .sql(Property.ofValue("SELECT * from test_table"))
+            .dryRun(Property.ofValue(true))
             .build();
 
         Query spy = Mockito.spy(task);

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/QueryErrorTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/QueryErrorTest.java
@@ -65,6 +65,56 @@ public class QueryErrorTest {
           }
         }""";
 
+    private static final String JOB_RESPONSE_RUNNING = """
+        {
+          "kind": "bigquery#job",
+          "etag": "\\"abcdef1234567890\\"",
+          "id": "kestra-unit-test:europe-west3.job_dup_test",
+          "jobReference": {
+            "projectId": "kestra-unit-test",
+            "jobId": "job_dup_test",
+            "location": "europe-west3"
+          },
+          "configuration": {
+            "query": {
+              "query": "SELECT * FROM `kestra-unit-test.my_dataset.my_table`",
+              "useLegacySql": false
+            },
+            "jobType": "QUERY"
+          },
+          "status": { "state": "RUNNING" },
+          "statistics": {
+            "creationTime": "1697123456789",
+            "startTime": "1697123457000"
+          }
+        }""";
+
+    private static final String JOB_RESPONSE_DUP_TEST_DONE = """
+        {
+          "kind": "bigquery#job",
+          "etag": "\\"abcdef1234567890\\"",
+          "id": "kestra-unit-test:europe-west3.job_dup_test",
+          "jobReference": {
+            "projectId": "kestra-unit-test",
+            "jobId": "job_dup_test",
+            "location": "europe-west3"
+          },
+          "configuration": {
+            "query": {
+              "query": "SELECT * FROM `kestra-unit-test.my_dataset.my_table`",
+              "useLegacySql": false
+            },
+            "jobType": "QUERY"
+          },
+          "status": { "state": "DONE" },
+          "statistics": {
+            "creationTime": "1697123456789",
+            "startTime": "1697123457000",
+            "endTime": "1697123459000",
+            "query": { "statementType": "SELECT" }
+          }
+        }""";
+
     private static final String BACKEND_ERROR_RESPONSE = """
         {
           "error": {
@@ -101,10 +151,11 @@ public class QueryErrorTest {
 
     @Test
     void shouldRetryOnBackendErrorWhenFetchingResults(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String jobsPath = "/bigquery/v2/projects/.*/jobs";
         String resultsPath = "/bigquery/v2/projects/.*/queries/job_1234567890abcdef";
 
         // Job creation and polling succeed
-        stubFor(post(urlPathMatching("/bigquery/v2/projects/.*/jobs"))
+        stubFor(post(urlPathMatching(jobsPath))
             .willReturn(aResponse()
                 .withStatus(200)
                 .withHeader("Content-Type", "application/json")
@@ -128,7 +179,70 @@ public class QueryErrorTest {
 
         assertThrows(Exception.class, () -> task.run(runContext));
 
-        verify(3, getRequestedFor(urlPathMatching(resultsPath)));
+        // job.waitFor() polls the same results endpoint and fails once before AbstractBigquery#waitForJob
+        // finds the already-completed job via getJob() and short-circuits without submitting a duplicate job;
+        // the 3 remaining hits come from the dedicated "fetch results" retry loop in Query#run.
+        verify(4, getRequestedFor(urlPathMatching(resultsPath)));
+        verify(1, postRequestedFor(urlPathMatching(jobsPath)));
+    }
+
+    @Test
+    void shouldNotDuplicateJobWhenPollingFailsAfterJobActuallySucceeded(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String jobsPath = "/bigquery/v2/projects/.*/jobs";
+        // job.waitFor() polls a query job via the queries endpoint (maxResults=0), not jobs/{id}.
+        String pollingPath = "/bigquery/v2/projects/.*/queries/job_dup_test.*";
+        // our fix looks up the last submitted job's status via BigQuery#getJob(JobId), which hits jobs/{id}.
+        String jobStatusPath = "/bigquery/v2/projects/.*/jobs/job_dup_test.*";
+
+        stubFor(post(urlPathMatching(jobsPath))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JOB_RESPONSE_RUNNING)));
+
+        // The poll consistently fails with a transient error, even though the job actually succeeded.
+        stubFor(get(urlPathMatching(pollingPath))
+            .willReturn(aResponse()
+                .withStatus(503)
+                .withHeader("Content-Type", "application/json")
+                .withBody(BACKEND_ERROR_RESPONSE)));
+
+        // The job's real status, fetched directly, shows it already completed successfully.
+        stubFor(get(urlPathMatching(jobStatusPath))
+            .willReturn(aResponse()
+                .withStatus(200)
+                .withHeader("Content-Type", "application/json")
+                .withBody(JOB_RESPONSE_DUP_TEST_DONE)));
+
+        Query task = buildQueryWithoutFetch(wmRuntimeInfo, 3);
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        Query.Output output = task.run(runContext);
+
+        assertEquals("job_dup_test", output.getJobId());
+        verify(1, postRequestedFor(urlPathMatching(jobsPath)));
+    }
+
+    private Query buildQueryWithoutFetch(WireMockRuntimeInfo wmRuntimeInfo, int maxAttempts) throws Exception {
+        Query task = Query.builder()
+            .id(QueryTest.class.getSimpleName())
+            .type(Query.class.getName())
+            .retryAuto(Exponential.builder()
+                .type("exponential")
+                .interval(Duration.ofMillis(100))
+                .maxInterval(Duration.ofMillis(500))
+                .maxDuration(Duration.ofSeconds(10))
+                .maxAttempts(maxAttempts)
+                .build())
+            .projectId(Property.ofValue(project))
+            .sql(Property.ofValue("SELECT * from test_table"))
+            .dryRun(Property.ofValue(false))
+            .build();
+
+        Query spy = Mockito.spy(task);
+        Mockito.doReturn(mockBigQueryClient(wmRuntimeInfo.getHttpBaseUrl()))
+            .when(spy).connection(Mockito.any(RunContext.class));
+        return spy;
     }
 
     private Query buildQuery(WireMockRuntimeInfo wmRuntimeInfo, int maxAttempts) throws Exception {


### PR DESCRIPTION
## Summary

- `AbstractBigquery#waitForJob` re-submitted a brand-new BigQuery job on every Failsafe retry attempt, even when the previously submitted job had actually completed successfully but a transient error (e.g. `backendError`) occurred while polling/fetching its status — causing duplicate data (e.g. duplicated partitions in `CopyPartitions`).
- Before creating a new job on retry, the previous attempt's `JobId` is now tracked and looked up via `BigQuery#getJob(JobId)`. If that job is found and already `DONE` with no error, it is returned directly and `createJob.call()` is skipped for that attempt. If the job is still running, we block on `.waitFor()` to reach a terminal state before deciding (avoids racing two jobs). If the job is not found or done-with-error, behavior falls through unchanged to creating a new job.
- The first attempt (no prior `JobId`) is unaffected — same behavior as before.
- Updated the 4 callers of `waitForJob` (`Copy`, `Query`, `LoadFromGcs`, `Load`) to pass their existing `BigQuery connection`. `ExtractToGcs` does not go through `waitForJob` and was left untouched, as it is out of scope for this issue.
- Added a WireMock-based regression test in `QueryErrorTest` reproducing a transient polling failure against an already-succeeded job, asserting only one job creation call is made.

closes: https://github.com/kestra-io/plugin-gcp/issues/648

## Test plan

- [x] `rtk test ./gradlew test` passes for the bigquery package (`QueryErrorTest`, including the new `shouldNotDuplicateJobWhenPollingFailsAfterJobActuallySucceeded` test)
- [x] `./gradlew compileJava compileTestJava` builds cleanly
- [ ] Manual QA against a real BigQuery project with an injected transient `backendError` (not exercised in this session, no live GCP credentials available)

---
*[View as Artifact](https://claude.ai/code/artifact/e9815b2d-ff98-4589-ab67-0d8c98002389)*