### PR TITLE
fix(bigquery): cancel underlying BigQuery job on task kill

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
@@ -85,16 +85,29 @@ abstract public class AbstractBigquery extends AbstractTask implements WorkerJob
 
     @JsonIgnore
     @Getter(AccessLevel.NONE)
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
     @Builder.Default
     private final AtomicReference<BigQuery> trackedConnection = new AtomicReference<>();
 
     @JsonIgnore
     @Getter(AccessLevel.NONE)
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
     @Builder.Default
     private final AtomicReference<JobId> trackedJobId = new AtomicReference<>();
 
     @JsonIgnore
     @Getter(AccessLevel.NONE)
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
+    @Builder.Default
+    private final AtomicReference<Logger> trackedLogger = new AtomicReference<>();
+
+    @JsonIgnore
+    @Getter(AccessLevel.NONE)
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
     @Builder.Default
     private final AtomicBoolean isCancelled = new AtomicBoolean(false);
 
@@ -102,9 +115,10 @@ abstract public class AbstractBigquery extends AbstractTask implements WorkerJob
      * Records the job currently submitted, so that {@link #kill()} or {@link #stop()} can cancel the
      * live BigQuery job instead of a stale one from a previous retry attempt.
      */
-    protected void trackJob(BigQuery connection, JobId jobId) {
+    protected void trackJob(BigQuery connection, JobId jobId, Logger logger) {
         this.trackedConnection.set(connection);
         this.trackedJobId.set(jobId);
+        this.trackedLogger.set(logger);
     }
 
     @Override
@@ -126,7 +140,12 @@ abstract public class AbstractBigquery extends AbstractTask implements WorkerJob
                 try {
                     connection.cancel(jobId);
                 } catch (Exception e) {
-                    LOG.warn("Failed to cancel BigQuery job '{}'", jobId, e);
+                    Logger logger = this.trackedLogger.get();
+                    if (logger != null) {
+                        logger.warn("Failed to cancel BigQuery job '{}'", jobId, e);
+                    } else {
+                        LOG.warn("Failed to cancel BigQuery job '{}'", jobId, e);
+                    }
                 }
             }
         }
@@ -219,7 +238,7 @@ abstract public class AbstractBigquery extends AbstractTask implements WorkerJob
 
                     job = createJob.call();
                     lastJobId.set(job.getJobId());
-                    this.trackJob(connection, job.getJobId());
+                    this.trackJob(connection, job.getJobId(), logger);
 
                     BigQueryService.handleErrors(job, logger);
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
@@ -96,11 +96,11 @@ abstract public class AbstractBigquery extends AbstractTask implements WorkerJob
     @JsonIgnore
     @Getter(AccessLevel.NONE)
     @Builder.Default
-    private final AtomicBoolean isKilled = new AtomicBoolean(false);
+    private final AtomicBoolean isCancelled = new AtomicBoolean(false);
 
     /**
-     * Records the job currently submitted, so that {@link #kill()} can cancel the live BigQuery job
-     * instead of a stale one from a previous retry attempt.
+     * Records the job currently submitted, so that {@link #kill()} or {@link #stop()} can cancel the
+     * live BigQuery job instead of a stale one from a previous retry attempt.
      */
     protected void trackJob(BigQuery connection, JobId jobId) {
         this.trackedConnection.set(connection);
@@ -109,7 +109,16 @@ abstract public class AbstractBigquery extends AbstractTask implements WorkerJob
 
     @Override
     public void kill() {
-        if (isKilled.compareAndSet(false, true)) {
+        cancelTrackedJob();
+    }
+
+    @Override
+    public void stop() {
+        cancelTrackedJob();
+    }
+
+    private void cancelTrackedJob() {
+        if (isCancelled.compareAndSet(false, true)) {
             BigQuery connection = this.trackedConnection.get();
             JobId jobId = this.trackedJobId.get();
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
@@ -6,16 +6,19 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.*;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
+import io.kestra.core.models.WorkerJobLifecycle;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.retrys.AbstractRetry;
@@ -33,7 +36,9 @@ import lombok.experimental.SuperBuilder;
 @EqualsAndHashCode
 @Getter
 @NoArgsConstructor
-abstract public class AbstractBigquery extends AbstractTask {
+abstract public class AbstractBigquery extends AbstractTask implements WorkerJobLifecycle {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractBigquery.class);
+
     @Schema(
         title = "Dataset location",
         description = "Optional BigQuery location for created or targeted resources. Experimental and may change; see BigQuery dataset location documentation."
@@ -77,6 +82,46 @@ abstract public class AbstractBigquery extends AbstractTask {
             "Retrying may solve the problem"
         )
     );
+
+    @JsonIgnore
+    @Getter(AccessLevel.NONE)
+    @Builder.Default
+    private final AtomicReference<BigQuery> trackedConnection = new AtomicReference<>();
+
+    @JsonIgnore
+    @Getter(AccessLevel.NONE)
+    @Builder.Default
+    private final AtomicReference<JobId> trackedJobId = new AtomicReference<>();
+
+    @JsonIgnore
+    @Getter(AccessLevel.NONE)
+    @Builder.Default
+    private final AtomicBoolean isKilled = new AtomicBoolean(false);
+
+    /**
+     * Records the job currently submitted, so that {@link #kill()} can cancel the live BigQuery job
+     * instead of a stale one from a previous retry attempt.
+     */
+    protected void trackJob(BigQuery connection, JobId jobId) {
+        this.trackedConnection.set(connection);
+        this.trackedJobId.set(jobId);
+    }
+
+    @Override
+    public void kill() {
+        if (isKilled.compareAndSet(false, true)) {
+            BigQuery connection = this.trackedConnection.get();
+            JobId jobId = this.trackedJobId.get();
+
+            if (connection != null && jobId != null) {
+                try {
+                    connection.cancel(jobId);
+                } catch (Exception e) {
+                    LOG.warn("Failed to cancel BigQuery job '{}'", jobId, e);
+                }
+            }
+        }
+    }
 
     BigQuery connection(RunContext runContext) throws IllegalVariableEvaluationException, IOException {
         GoogleCredentials credentials = this.credentials(runContext);
@@ -165,6 +210,7 @@ abstract public class AbstractBigquery extends AbstractTask {
 
                     job = createJob.call();
                     lastJobId.set(job.getJobId());
+                    this.trackJob(connection, job.getJobId());
 
                     BigQueryService.handleErrors(job, logger);
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/CopyPartitions.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/CopyPartitions.java
@@ -189,6 +189,15 @@ public class CopyPartitions extends AbstractPartition implements RunnableTask<Co
         }
     }
 
+    @Override
+    public void stop() {
+        Copy task = this.copyTask.get();
+
+        if (task != null) {
+            task.stop();
+        }
+    }
+
     @Getter
     @Builder
     public static class Output implements io.kestra.core.models.tasks.Output {

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/CopyPartitions.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/CopyPartitions.java
@@ -114,6 +114,8 @@ public class CopyPartitions extends AbstractPartition implements RunnableTask<Co
 
     @JsonIgnore
     @Getter(AccessLevel.NONE)
+    @EqualsAndHashCode.Exclude
+    @ToString.Exclude
     @Builder.Default
     private final AtomicReference<Copy> copyTask = new AtomicReference<>();
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/CopyPartitions.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/CopyPartitions.java
@@ -4,10 +4,12 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.JobInfo;
 import com.google.cloud.bigquery.TableId;
@@ -110,6 +112,11 @@ public class CopyPartitions extends AbstractPartition implements RunnableTask<Co
     )
     protected Property<Boolean> skipEmpty = Property.ofValue(false);
 
+    @JsonIgnore
+    @Getter(AccessLevel.NONE)
+    @Builder.Default
+    private final AtomicReference<Copy> copyTask = new AtomicReference<>();
+
     @Override
     public CopyPartitions.Output run(RunContext runContext) throws Exception {
         BigQuery connection = this.connection(runContext);
@@ -166,9 +173,20 @@ public class CopyPartitions extends AbstractPartition implements RunnableTask<Co
             .scopes(this.scopes)
             .build();
 
+        this.copyTask.set(task);
+
         Copy.Output run = task.run(runContext);
 
         return Output.of(tableId, partitionToCopy, run.getJobId());
+    }
+
+    @Override
+    public void kill() {
+        Copy task = this.copyTask.get();
+
+        if (task != null) {
+            task.kill();
+        }
     }
 
     @Getter

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/ExtractToGcs.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/ExtractToGcs.java
@@ -132,6 +132,7 @@ public class ExtractToGcs extends AbstractBigquery implements RunnableTask<Extra
         ExtractJobConfiguration configuration = this.buildExtractJob(runContext);
 
         Job extractJob = connection.create(JobInfo.of(configuration));
+        this.trackJob(connection, extractJob.getJobId());
 
         logger.debug("Starting query\n{}", JacksonMapper.log(configuration));
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/ExtractToGcs.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/ExtractToGcs.java
@@ -132,7 +132,7 @@ public class ExtractToGcs extends AbstractBigquery implements RunnableTask<Extra
         ExtractJobConfiguration configuration = this.buildExtractJob(runContext);
 
         Job extractJob = connection.create(JobInfo.of(configuration));
-        this.trackJob(connection, extractJob.getJobId());
+        this.trackJob(connection, extractJob.getJobId(), logger);
 
         logger.debug("Starting query\n{}", JacksonMapper.log(configuration));
 

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/AbstractBigqueryKillTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/AbstractBigqueryKillTest.java
@@ -1,0 +1,72 @@
+package io.kestra.plugin.gcp.bigquery;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.JobId;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AbstractBigqueryKillTest {
+    @Test
+    void killCancelsTrackedJob() {
+        Copy task = Copy.builder().build();
+        BigQuery connection = mock(BigQuery.class);
+        JobId jobId = JobId.of("my-project", "my-job");
+
+        task.trackJob(connection, jobId);
+        task.kill();
+
+        verify(connection, times(1)).cancel(jobId);
+    }
+
+    @Test
+    void secondKillIsNoOp() {
+        Copy task = Copy.builder().build();
+        BigQuery connection = mock(BigQuery.class);
+        JobId jobId = JobId.of("my-project", "my-job");
+
+        task.trackJob(connection, jobId);
+        task.kill();
+        task.kill();
+
+        verify(connection, times(1)).cancel(jobId);
+    }
+
+    @Test
+    void killOnRetryTracksLatestJobOnly() {
+        Copy task = Copy.builder().build();
+        BigQuery connection = mock(BigQuery.class);
+        JobId staleJobId = JobId.of("my-project", "stale-job");
+        JobId liveJobId = JobId.of("my-project", "live-job");
+
+        task.trackJob(connection, staleJobId);
+        task.trackJob(connection, liveJobId);
+        task.kill();
+
+        verify(connection, times(1)).cancel(liveJobId);
+        verify(connection, times(0)).cancel(staleJobId);
+    }
+
+    @Test
+    void killWithoutTrackedJobIsNoOp() {
+        Copy task = Copy.builder().build();
+
+        assertDoesNotThrow(task::kill);
+    }
+
+    @Test
+    void killSwallowsCancelException() {
+        Copy task = Copy.builder().build();
+        BigQuery connection = mock(BigQuery.class);
+        JobId jobId = JobId.of("my-project", "my-job");
+        when(connection.cancel(jobId)).thenThrow(new com.google.cloud.bigquery.BigQueryException(500, "boom"));
+
+        task.trackJob(connection, jobId);
+
+        assertDoesNotThrow(task::kill);
+    }
+}

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/AbstractBigqueryLifecycleTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/AbstractBigqueryLifecycleTest.java
@@ -3,6 +3,8 @@ package io.kestra.plugin.gcp.bigquery;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.JobId;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.Mockito.mock;
@@ -11,13 +13,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class AbstractBigqueryLifecycleTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractBigqueryLifecycleTest.class);
+
     @Test
     void killCancelsTrackedJob() {
         Copy task = Copy.builder().build();
         BigQuery connection = mock(BigQuery.class);
         JobId jobId = JobId.of("my-project", "my-job");
 
-        task.trackJob(connection, jobId);
+        task.trackJob(connection, jobId, LOGGER);
         task.kill();
 
         verify(connection, times(1)).cancel(jobId);
@@ -29,7 +33,7 @@ class AbstractBigqueryLifecycleTest {
         BigQuery connection = mock(BigQuery.class);
         JobId jobId = JobId.of("my-project", "my-job");
 
-        task.trackJob(connection, jobId);
+        task.trackJob(connection, jobId, LOGGER);
         task.kill();
         task.kill();
 
@@ -43,8 +47,8 @@ class AbstractBigqueryLifecycleTest {
         JobId staleJobId = JobId.of("my-project", "stale-job");
         JobId liveJobId = JobId.of("my-project", "live-job");
 
-        task.trackJob(connection, staleJobId);
-        task.trackJob(connection, liveJobId);
+        task.trackJob(connection, staleJobId, LOGGER);
+        task.trackJob(connection, liveJobId, LOGGER);
         task.kill();
 
         verify(connection, times(1)).cancel(liveJobId);
@@ -65,7 +69,7 @@ class AbstractBigqueryLifecycleTest {
         JobId jobId = JobId.of("my-project", "my-job");
         when(connection.cancel(jobId)).thenThrow(new com.google.cloud.bigquery.BigQueryException(500, "boom"));
 
-        task.trackJob(connection, jobId);
+        task.trackJob(connection, jobId, LOGGER);
 
         assertDoesNotThrow(task::kill);
     }
@@ -76,7 +80,7 @@ class AbstractBigqueryLifecycleTest {
         BigQuery connection = mock(BigQuery.class);
         JobId jobId = JobId.of("my-project", "my-job");
 
-        task.trackJob(connection, jobId);
+        task.trackJob(connection, jobId, LOGGER);
         task.stop();
 
         verify(connection, times(1)).cancel(jobId);
@@ -88,7 +92,7 @@ class AbstractBigqueryLifecycleTest {
         BigQuery connection = mock(BigQuery.class);
         JobId jobId = JobId.of("my-project", "my-job");
 
-        task.trackJob(connection, jobId);
+        task.trackJob(connection, jobId, LOGGER);
         task.stop();
         task.stop();
 
@@ -101,7 +105,7 @@ class AbstractBigqueryLifecycleTest {
         BigQuery connection = mock(BigQuery.class);
         JobId jobId = JobId.of("my-project", "my-job");
 
-        task.trackJob(connection, jobId);
+        task.trackJob(connection, jobId, LOGGER);
         task.kill();
         task.stop();
 
@@ -114,7 +118,7 @@ class AbstractBigqueryLifecycleTest {
         BigQuery connection = mock(BigQuery.class);
         JobId jobId = JobId.of("my-project", "my-job");
 
-        task.trackJob(connection, jobId);
+        task.trackJob(connection, jobId, LOGGER);
         task.stop();
         task.kill();
 
@@ -135,7 +139,7 @@ class AbstractBigqueryLifecycleTest {
         JobId jobId = JobId.of("my-project", "my-job");
         when(connection.cancel(jobId)).thenThrow(new com.google.cloud.bigquery.BigQueryException(500, "boom"));
 
-        task.trackJob(connection, jobId);
+        task.trackJob(connection, jobId, LOGGER);
 
         assertDoesNotThrow(task::stop);
     }

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/AbstractBigqueryLifecycleTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/AbstractBigqueryLifecycleTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class AbstractBigqueryKillTest {
+class AbstractBigqueryLifecycleTest {
     @Test
     void killCancelsTrackedJob() {
         Copy task = Copy.builder().build();
@@ -68,5 +68,75 @@ class AbstractBigqueryKillTest {
         task.trackJob(connection, jobId);
 
         assertDoesNotThrow(task::kill);
+    }
+
+    @Test
+    void stopCancelsTrackedJob() {
+        Copy task = Copy.builder().build();
+        BigQuery connection = mock(BigQuery.class);
+        JobId jobId = JobId.of("my-project", "my-job");
+
+        task.trackJob(connection, jobId);
+        task.stop();
+
+        verify(connection, times(1)).cancel(jobId);
+    }
+
+    @Test
+    void secondStopIsNoOp() {
+        Copy task = Copy.builder().build();
+        BigQuery connection = mock(BigQuery.class);
+        JobId jobId = JobId.of("my-project", "my-job");
+
+        task.trackJob(connection, jobId);
+        task.stop();
+        task.stop();
+
+        verify(connection, times(1)).cancel(jobId);
+    }
+
+    @Test
+    void stopAfterKillIsNoOp() {
+        Copy task = Copy.builder().build();
+        BigQuery connection = mock(BigQuery.class);
+        JobId jobId = JobId.of("my-project", "my-job");
+
+        task.trackJob(connection, jobId);
+        task.kill();
+        task.stop();
+
+        verify(connection, times(1)).cancel(jobId);
+    }
+
+    @Test
+    void killAfterStopIsNoOp() {
+        Copy task = Copy.builder().build();
+        BigQuery connection = mock(BigQuery.class);
+        JobId jobId = JobId.of("my-project", "my-job");
+
+        task.trackJob(connection, jobId);
+        task.stop();
+        task.kill();
+
+        verify(connection, times(1)).cancel(jobId);
+    }
+
+    @Test
+    void stopWithoutTrackedJobIsNoOp() {
+        Copy task = Copy.builder().build();
+
+        assertDoesNotThrow(task::stop);
+    }
+
+    @Test
+    void stopSwallowsCancelException() {
+        Copy task = Copy.builder().build();
+        BigQuery connection = mock(BigQuery.class);
+        JobId jobId = JobId.of("my-project", "my-job");
+        when(connection.cancel(jobId)).thenThrow(new com.google.cloud.bigquery.BigQueryException(500, "boom"));
+
+        task.trackJob(connection, jobId);
+
+        assertDoesNotThrow(task::stop);
     }
 }

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/CopyPartitionsKillTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/CopyPartitionsKillTest.java
@@ -29,6 +29,24 @@ class CopyPartitionsKillTest {
         assertDoesNotThrow(task::kill);
     }
 
+    @Test
+    void stopForwardsToNestedCopyTask() throws Exception {
+        CopyPartitions task = CopyPartitions.builder().build();
+        Copy copy = mock(Copy.class);
+
+        trackedCopyTask(task).set(copy);
+        task.stop();
+
+        verify(copy, times(1)).stop();
+    }
+
+    @Test
+    void stopWithoutNestedCopyTaskIsNoOp() {
+        CopyPartitions task = CopyPartitions.builder().build();
+
+        assertDoesNotThrow(task::stop);
+    }
+
     @SuppressWarnings("unchecked")
     private static AtomicReference<Copy> trackedCopyTask(CopyPartitions task) throws Exception {
         Field field = CopyPartitions.class.getDeclaredField("copyTask");

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/CopyPartitionsKillTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/CopyPartitionsKillTest.java
@@ -1,0 +1,38 @@
+package io.kestra.plugin.gcp.bigquery;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class CopyPartitionsKillTest {
+    @Test
+    void killForwardsToNestedCopyTask() throws Exception {
+        CopyPartitions task = CopyPartitions.builder().build();
+        Copy copy = mock(Copy.class);
+
+        trackedCopyTask(task).set(copy);
+        task.kill();
+
+        verify(copy, times(1)).kill();
+    }
+
+    @Test
+    void killWithoutNestedCopyTaskIsNoOp() {
+        CopyPartitions task = CopyPartitions.builder().build();
+
+        assertDoesNotThrow(task::kill);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static AtomicReference<Copy> trackedCopyTask(CopyPartitions task) throws Exception {
+        Field field = CopyPartitions.class.getDeclaredField("copyTask");
+        field.setAccessible(true);
+        return (AtomicReference<Copy>) field.get(task);
+    }
+}


### PR DESCRIPTION
## Summary

- `AbstractBigquery` now tracks the `BigQuery` connection and `JobId` of the job currently in flight (`trackJob()`) and overrides `kill()` and `stop()` to call `BigQuery#cancel(JobId)` on it, guarded by a shared `AtomicBoolean` so a duplicate/racing kill and/or stop is a no-op regardless of which lifecycle event fires first.
- `waitForJob()` calls `trackJob()` right after every `createJob.call()`, including retries, so a kill or stop during a retry cancels the live job rather than a stale one. `Query`, `Copy`, `Load`, and `LoadFromGcs` all funnel through it and get the fix for free.
- `ExtractToGcs` tracks its extract job directly since it doesn't go through `waitForJob()`.
- `CopyPartitions` builds a nested `Copy` task per run; it now stores a reference to it and forwards both `kill()` and `stop()` to it, same as `kill()`.
- `StorageWrite` and `DeletePartitions` are intentionally untouched — neither submits a cancellable Jobs-API job.

closes: https://github.com/kestra-io/plugin-gcp/issues/656

## Test plan

- [x] `rtk test ./gradlew test` passes (full suite, 0 failures/errors)
- [ ] `./gradlew shadowJar` builds
- [x] New unit tests: `AbstractBigqueryLifecycleTest` (cancel called once via `kill()` or `stop()`, no-op on second kill/stop or kill-after-stop/stop-after-kill, no-op with no tracked job, retry tracks latest job only, cancel exceptions swallowed) and `CopyPartitionsKillTest` (forwarding of both `kill()` and `stop()` to the nested `Copy` task)

---
*[View as Artifact](https://claude.ai/code/artifact/a3ae95f2-b933-4625-8fb6-e84f9813a623)*
