### PR TITLE
fix(build): restore META-INF/services merging in shadowJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -247,6 +247,28 @@ shadowJar {
     mergeServiceFiles()
 }
 
+// Regression guard for the pick_first bug (see PR fixing duplicatesStrategy above): loads the
+// shaded jar in an isolated classloader, same as Kestra's per-plugin isolation, and asks grpc's
+// real LoadBalancerRegistry for "pick_first" -- the exact call that throws at runtime if the
+// shadowJar merge of META-INF/services/io.grpc.LoadBalancerProvider regresses.
+tasks.register("verifyShadedGrpcLoadBalancers") {
+    dependsOn shadowJar
+    doLast {
+        def jarFile = shadowJar.archiveFile.get().asFile
+        def loader = new URLClassLoader([jarFile.toURI().toURL()] as URL[], ClassLoader.getPlatformClassLoader())
+        def registryClass = loader.loadClass("io.grpc.LoadBalancerRegistry")
+        def registry = registryClass.getMethod("getDefaultRegistry").invoke(null)
+        def provider = registryClass.getMethod("getProvider", String).invoke(registry, "pick_first")
+        if (provider == null) {
+            throw new GradleException(
+                "pick_first LoadBalancerProvider missing from ${jarFile.name}'s META-INF/services/io.grpc.LoadBalancerProvider " +
+                "-- shadowJar's service file merge regressed, every grpc-based client (e.g. GKE ClusterMetadata) will fail at runtime."
+            )
+        }
+    }
+}
+check.dependsOn verifyShadedGrpcLoadBalancers
+
 
 /**********************************************************************************************************************\
  * Version

--- a/build.gradle
+++ b/build.gradle
@@ -239,6 +239,11 @@ jar {
 shadowJar {
     zip64 true
     archiveClassifier.set(null)
+    // Shadow 9.0.1+ changed the default duplicatesStrategy to EXCLUDE, which drops every
+    // duplicate META-INF/services entry before mergeServiceFiles() ever sees it — e.g. only
+    // grpc-util's io.grpc.LoadBalancerProvider survived, silently losing grpc-core's pick_first
+    // provider and breaking every grpc-based client (GKE ClusterMetadata, etc.) at runtime.
+    duplicatesStrategy = DuplicatesStrategy.INCLUDE
     mergeServiceFiles()
 }
 


### PR DESCRIPTION
## Summary
- Shadow 9.0.1 changed shadowJar's default `duplicatesStrategy` to `EXCLUDE`, so duplicate `META-INF/services` entries across dependency jars get dropped before `mergeServiceFiles()` ever runs — only `grpc-util`'s `io.grpc.LoadBalancerProvider` file survived the shading step, silently losing `grpc-core`'s `pick_first` provider (and `grpc-xds`/`grpc-rls`/`grpc-grpclb`'s entries too).
- Any task using a grpc-based client (e.g. `io.kestra.plugin.gcp.gke.ClusterMetadata`) fails at runtime with:
  ```
  INTERNAL: Could not find policy 'pick_first'. Make sure its implementation is either registered to LoadBalancerRegistry or included in META-INF/services/io.grpc.LoadBalancerProvider from your jar files.
  ```
- Fix: set `duplicatesStrategy = DuplicatesStrategy.INCLUDE` on `shadowJar` so `mergeServiceFiles()` actually sees every duplicate and merges them.
- Reproduced against v2.7.4 too (pinning the plugin version does not help — this is a build/packaging bug, not a dependency-version conflict).

## Test plan
- [x] Built shaded jar before fix: `unzip -p plugin-gcp-*.jar META-INF/services/io.grpc.LoadBalancerProvider` → only 3 `grpc-util` entries, no `pick_first`.
- [x] Applied fix, rebuilt: merged file now contains all 16 providers across `grpc-core`, `grpc-util`, `grpc-xds`, `grpc-rls`, `grpc-grpclb`.
- [ ] CI build/tests green.