### PR TITLE
feat(rcs): add Google RCS Business Messaging (RBM) sub-plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,10 @@ Single-module plugin. Source packages under `io.kestra.plugin`:
 - `io.kestra.plugin.gcp.pubsub.Publish`
 - `io.kestra.plugin.gcp.pubsub.RealtimeTrigger`
 - `io.kestra.plugin.gcp.pubsub.Trigger`
+- `io.kestra.plugin.gcp.rcs.SendCarousel`
+- `io.kestra.plugin.gcp.rcs.SendFile`
+- `io.kestra.plugin.gcp.rcs.SendMessage`
+- `io.kestra.plugin.gcp.rcs.SendRichCard`
 - `io.kestra.plugin.gcp.vertexai.ChatCompletion`
 - `io.kestra.plugin.gcp.vertexai.CustomJob`
 - `io.kestra.plugin.gcp.vertexai.MultimodalCompletion`

--- a/src/main/java/io/kestra/plugin/gcp/rcs/AbstractRcs.java
+++ b/src/main/java/io/kestra/plugin/gcp/rcs/AbstractRcs.java
@@ -5,6 +5,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import io.kestra.core.http.HttpRequest;
 import io.kestra.core.http.HttpResponse;
 import io.kestra.core.http.client.HttpClient;
@@ -30,26 +32,28 @@ public abstract class AbstractRcs extends AbstractTask {
 
     @Schema(title = "The unique agent ID of the Brand Agent configured on the RBM platform")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main", secret = true)
     protected Property<String> agentId;
 
     @Schema(title = "The recipient's phone number (MSISDN) in E.164 format (e.g. +33612345678)")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     protected Property<String> msisdn;
 
     @Builder.Default
     @Getter(AccessLevel.NONE)
+    @JsonIgnore
     protected String baseUrl = "https://rcsbusinessmessaging.googleapis.com";
-
-    @Builder.Default
-    protected Property<List<String>> scopes = Property.ofValue(Collections.singletonList("https://www.googleapis.com/auth/rcsbusinessmessaging"));
 
     protected String getAccessToken(RunContext runContext) throws Exception {
         return this.credentials(runContext)
-            .createScoped(runContext.render(this.scopes).asList(String.class))
             .refreshAccessToken()
             .getTokenValue();
+    }
+
+    @Override
+    public Property<List<String>> getScopes() {
+        return Property.ofValue(Collections.singletonList("https://www.googleapis.com/auth/rcsbusinessmessaging"));
     }
 
     protected HttpResponse<String> executeRequest(RunContext runContext, String endpointPath, String httpMethod, HttpRequest.RequestBody requestBody) throws Exception {

--- a/src/main/java/io/kestra/plugin/gcp/rcs/AbstractRcs.java
+++ b/src/main/java/io/kestra/plugin/gcp/rcs/AbstractRcs.java
@@ -1,0 +1,97 @@
+package io.kestra.plugin.gcp.rcs;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.List;
+
+import io.kestra.core.http.HttpRequest;
+import io.kestra.core.http.HttpResponse;
+import io.kestra.core.http.client.HttpClient;
+import io.kestra.core.http.client.HttpClientResponseException;
+import io.kestra.core.http.client.configurations.HttpConfiguration;
+import io.kestra.core.http.client.configurations.TimeoutConfiguration;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.plugin.gcp.AbstractTask;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode(callSuper = true)
+@Getter
+@NoArgsConstructor
+public abstract class AbstractRcs extends AbstractTask {
+
+    @Schema(title = "The unique agent ID of the Brand Agent configured on the RBM platform")
+    @NotNull
+    @PluginProperty
+    protected Property<String> agentId;
+
+    @Schema(title = "The recipient's phone number (MSISDN) in E.164 format (e.g. +33612345678)")
+    @NotNull
+    @PluginProperty
+    protected Property<String> msisdn;
+
+    @Builder.Default
+    @Getter(AccessLevel.NONE)
+    protected String baseUrl = "https://rcsbusinessmessaging.googleapis.com";
+
+    @Builder.Default
+    protected Property<List<String>> scopes = Property.ofValue(Collections.singletonList("https://www.googleapis.com/auth/rcsbusinessmessaging"));
+
+    protected String getAccessToken(RunContext runContext) throws Exception {
+        return this.credentials(runContext)
+            .createScoped(runContext.render(this.scopes).asList(String.class))
+            .refreshAccessToken()
+            .getTokenValue();
+    }
+
+    protected HttpResponse<String> executeRequest(RunContext runContext, String endpointPath, String httpMethod, HttpRequest.RequestBody requestBody) throws Exception {
+        var token = getAccessToken(runContext);
+        var rAgentId = runContext.render(this.agentId).as(String.class).orElseThrow();
+
+        var renderedPath = runContext.render(endpointPath);
+        var separator = renderedPath.contains("?") ? "&" : "?";
+        var targetUrl = this.baseUrl + renderedPath + separator + "agentId=" + java.net.URLEncoder.encode(rAgentId, StandardCharsets.UTF_8);
+
+        try (
+            var client = new HttpClient(
+                runContext,
+                HttpConfiguration.builder()
+                    .timeout(
+                        TimeoutConfiguration.builder()
+                            .readIdleTimeout(Property.ofValue(java.time.Duration.ofSeconds(60)))
+                            .build()
+                    )
+                    .build()
+            )
+        ) {
+            var requestBuilder = HttpRequest.builder()
+                .uri(new URI(targetUrl))
+                .method(httpMethod)
+                .addHeader("Authorization", "Bearer " + token)
+                .addHeader("Content-Type", "application/json");
+
+            if (requestBody != null) {
+                requestBuilder.body(requestBody);
+            }
+
+            return client.request(requestBuilder.build(), String.class);
+        } catch (HttpClientResponseException e) {
+            var resp = e.getResponse();
+            var code = resp != null && resp.getStatus() != null ? resp.getStatus().getCode() : -1;
+            var body = resp != null && resp.getBody() != null ? String.valueOf(resp.getBody()) : "<empty>";
+            throw new HttpClientResponseException(
+                "RBM API request failed with status code " + code + ". Response body: " + body,
+                resp,
+                e
+            );
+        }
+    }
+}

--- a/src/main/java/io/kestra/plugin/gcp/rcs/Card.java
+++ b/src/main/java/io/kestra/plugin/gcp/rcs/Card.java
@@ -1,0 +1,66 @@
+package io.kestra.plugin.gcp.rcs;
+
+import java.util.*;
+
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import lombok.extern.jackson.Jacksonized;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Jacksonized
+public class Card {
+    @Schema(title = "The card title")
+    @PluginProperty
+    private Property<String> title;
+
+    @Schema(title = "The card description")
+    @PluginProperty
+    private Property<String> description;
+
+    @Schema(title = "The card media/image URL")
+    @PluginProperty
+    private Property<String> imageUrl;
+
+    @Schema(title = "The list of suggested actions/replies (max 4 per card)")
+    @PluginProperty
+    private List<Suggestion> suggestions;
+
+    public Map<String, Object> toRbmCardContent(RunContext runContext) throws Exception {
+        var cardContent = new HashMap<String, Object>();
+        if (this.title != null) {
+            runContext.render(this.title).as(String.class).ifPresent(t -> cardContent.put("title", t));
+        }
+        if (this.description != null) {
+            runContext.render(this.description).as(String.class).ifPresent(d -> cardContent.put("description", d));
+        }
+        if (this.imageUrl != null) {
+            var rImageUrl = runContext.render(this.imageUrl).as(String.class).orElse(null);
+            if (rImageUrl != null) {
+                cardContent.put(
+                    "media", Map.of(
+                        "height", "MEDIUM",
+                        "contentInfo", Map.of("fileUrl", rImageUrl)
+                    )
+                );
+            }
+        }
+        if (this.suggestions != null && !this.suggestions.isEmpty()) {
+            if (this.suggestions.size() > 4) {
+                throw new IllegalArgumentException("RCS Card suggestions cannot exceed 4 items");
+            }
+            var rbmSuggestions = new ArrayList<Map<String, Object>>();
+            for (var s : this.suggestions) {
+                rbmSuggestions.add(s.toRbmSuggestion(runContext));
+            }
+            cardContent.put("suggestions", rbmSuggestions);
+        }
+        return cardContent;
+    }
+}

--- a/src/main/java/io/kestra/plugin/gcp/rcs/SendCarousel.java
+++ b/src/main/java/io/kestra/plugin/gcp/rcs/SendCarousel.java
@@ -63,7 +63,7 @@ public class SendCarousel extends AbstractRcs implements RunnableTask<SendCarous
 
     @Schema(title = "The list of rich cards in the carousel (between 2 and 10 cards)")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     private List<Card> cards;
 
     @Override

--- a/src/main/java/io/kestra/plugin/gcp/rcs/SendCarousel.java
+++ b/src/main/java/io/kestra/plugin/gcp/rcs/SendCarousel.java
@@ -1,0 +1,122 @@
+package io.kestra.plugin.gcp.rcs;
+
+import java.time.Instant;
+import java.util.*;
+
+import io.kestra.core.http.HttpRequest;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.JacksonMapper;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode(callSuper = true)
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Send a carousel of Rich Cards to a recipient's phone number",
+    description = "Sends a horizontal scrolling list of 2 to 10 rich media cards."
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Send a carousel of rich cards",
+            full = true,
+            code = """
+                id: rcs_send_carousel
+                namespace: company.team
+
+                tasks:
+                  - id: send_carousel
+                    type: io.kestra.plugin.gcp.rcs.SendCarousel
+                    serviceAccount: "{{ secret('GCP_SERVICE_ACCOUNT') }}"
+                    agentId: "{{ secret('RBM_AGENT_ID') }}"
+                    msisdn: "+33612345678"
+                    cards:
+                      - title: "Item 1"
+                        description: "First option description"
+                        imageUrl: "https://example.com/item1.jpg"
+                        suggestions:
+                          - type: REPLY
+                            text: "Select Item 1"
+                            postbackData: "select_1"
+                      - title: "Item 2"
+                        description: "Second option description"
+                        imageUrl: "https://example.com/item2.jpg"
+                        suggestions:
+                          - type: REPLY
+                            text: "Select Item 2"
+                            postbackData: "select_2"
+                """
+        )
+    }
+)
+public class SendCarousel extends AbstractRcs implements RunnableTask<SendCarousel.Output> {
+
+    @Schema(title = "The list of rich cards in the carousel (between 2 and 10 cards)")
+    @NotNull
+    @PluginProperty
+    private List<Card> cards;
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+        var rMsisdn = runContext.render(this.msisdn).as(String.class).orElseThrow();
+
+        if (this.cards == null || this.cards.size() < 2 || this.cards.size() > 10) {
+            throw new IllegalArgumentException("RCS Carousel must contain between 2 and 10 cards");
+        }
+
+        var cardContents = new ArrayList<Map<String, Object>>();
+        for (var card : this.cards) {
+            cardContents.add(card.toRbmCardContent(runContext));
+        }
+
+        var payload = Map.of(
+            "messageId", UUID.randomUUID().toString(),
+            "contentMessage", Map.of(
+                "richCard", Map.of(
+                    "carouselCard", Map.of(
+                        "cardWidth", "MEDIUM",
+                        "cardContents", cardContents
+                    )
+                )
+            )
+        );
+
+        var endpointPath = "/v1/phones/" + java.net.URLEncoder.encode(rMsisdn, java.nio.charset.StandardCharsets.UTF_8) + "/agentMessages";
+        var response = this.executeRequest(
+            runContext,
+            endpointPath,
+            "POST",
+            HttpRequest.JsonRequestBody.builder().content(payload).build()
+        );
+
+        var responseBody = JacksonMapper.toMap(response.getBody());
+        var messageId = (String) responseBody.get("messageId");
+        var sendTimeStr = (String) responseBody.get("sendTime");
+        var sendTime = sendTimeStr != null ? Instant.parse(sendTimeStr) : Instant.now();
+
+        return Output.builder()
+            .messageId(messageId)
+            .sendTime(sendTime)
+            .build();
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(title = "The unique message ID assigned by the RBM platform")
+        private final String messageId;
+
+        @Schema(title = "The timestamp when the message was sent")
+        private final Instant sendTime;
+    }
+}

--- a/src/main/java/io/kestra/plugin/gcp/rcs/SendFile.java
+++ b/src/main/java/io/kestra/plugin/gcp/rcs/SendFile.java
@@ -56,11 +56,11 @@ public class SendFile extends AbstractRcs implements RunnableTask<SendFile.Outpu
 
     @Schema(title = "The file attachment URI (can be a public HTTPS URL or a Kestra internal storage URI)")
     @NotNull
-    @PluginProperty(internalStorageURI = true)
+    @PluginProperty(group = "main", internalStorageURI = true)
     private Property<String> file;
 
     @Schema(title = "Optional thumbnail image URI (can be a public HTTPS URL or a Kestra internal storage URI)")
-    @PluginProperty(internalStorageURI = true)
+    @PluginProperty(group = "main", internalStorageURI = true)
     private Property<String> thumbnail;
 
     @Override

--- a/src/main/java/io/kestra/plugin/gcp/rcs/SendFile.java
+++ b/src/main/java/io/kestra/plugin/gcp/rcs/SendFile.java
@@ -1,0 +1,172 @@
+package io.kestra.plugin.gcp.rcs;
+
+import java.net.URI;
+import java.net.URLConnection;
+import java.time.Instant;
+import java.util.*;
+
+import io.kestra.core.http.HttpRequest;
+import io.kestra.core.http.HttpResponse;
+import io.kestra.core.http.client.HttpClient;
+import io.kestra.core.http.client.configurations.HttpConfiguration;
+import io.kestra.core.http.client.configurations.TimeoutConfiguration;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.JacksonMapper;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode(callSuper = true)
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Send a file attachment to a recipient's phone number",
+    description = "Uploads and sends a media attachment (image, video, audio, or PDF) to a user via RBM."
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Send a file attachment from a public URL",
+            full = true,
+            code = """
+                id: rcs_send_file
+                namespace: company.team
+
+                tasks:
+                  - id: send_file
+                    type: io.kestra.plugin.gcp.rcs.SendFile
+                    serviceAccount: "{{ secret('GCP_SERVICE_ACCOUNT') }}"
+                    agentId: "{{ secret('RBM_AGENT_ID') }}"
+                    msisdn: "+33612345678"
+                    file: "https://example.com/delivery-receipt.pdf"
+                """
+        )
+    }
+)
+public class SendFile extends AbstractRcs implements RunnableTask<SendFile.Output> {
+
+    @Schema(title = "The file attachment URI (can be a public HTTPS URL or a Kestra internal storage URI)")
+    @NotNull
+    @PluginProperty(internalStorageURI = true)
+    private Property<String> file;
+
+    @Schema(title = "Optional thumbnail image URI (can be a public HTTPS URL or a Kestra internal storage URI)")
+    @PluginProperty(internalStorageURI = true)
+    private Property<String> thumbnail;
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+        var rMsisdn = runContext.render(this.msisdn).as(String.class).orElseThrow();
+        var rFile = runContext.render(this.file).as(String.class).orElseThrow();
+        var rThumbnail = this.thumbnail != null ? runContext.render(this.thumbnail).as(String.class).orElse(null) : null;
+
+        String fileId;
+
+        if (rFile.startsWith("http://") || rFile.startsWith("https://")) {
+            var fileMetadata = new HashMap<String, Object>();
+            fileMetadata.put("fileUrl", rFile);
+            fileMetadata.put("agentId", runContext.render(this.agentId).as(String.class).orElseThrow());
+            if (rThumbnail != null) {
+                fileMetadata.put("thumbnailUrl", rThumbnail);
+            }
+
+            var response = this.executeRequest(
+                runContext,
+                "/v1/files",
+                "POST",
+                HttpRequest.JsonRequestBody.builder().content(fileMetadata).build()
+            );
+            var responseBody = JacksonMapper.toMap(response.getBody());
+            fileId = (String) responseBody.get("name");
+        } else {
+            var fileUri = new URI(rFile);
+
+            var filename = fileUri.getPath();
+            String mimeType = null;
+            if (filename != null) {
+                mimeType = URLConnection.guessContentTypeFromName(filename);
+            }
+            if (mimeType == null) {
+                mimeType = "application/octet-stream";
+            }
+
+            HttpResponse<String> uploadResponse;
+            try (var is = runContext.storage().getFile(fileUri)) {
+                var token = getAccessToken(runContext);
+                var rAgentId = runContext.render(this.agentId).as(String.class).orElseThrow();
+                var targetUrl = this.baseUrl + "/upload/v1/files?agentId=" + java.net.URLEncoder.encode(rAgentId, java.nio.charset.StandardCharsets.UTF_8);
+
+                try (
+                    var client = new HttpClient(
+                        runContext,
+                        HttpConfiguration.builder()
+                            .timeout(
+                                TimeoutConfiguration.builder()
+                                    .readIdleTimeout(Property.ofValue(java.time.Duration.ofSeconds(60)))
+                                    .build()
+                            )
+                            .build()
+                    )
+                ) {
+                    var requestBuilder = HttpRequest.builder()
+                        .uri(new URI(targetUrl))
+                        .method("POST")
+                        .addHeader("Authorization", "Bearer " + token)
+                        .addHeader("Content-Type", mimeType)
+                        .body(HttpRequest.InputStreamRequestBody.of(is));
+
+                    uploadResponse = client.request(requestBuilder.build(), String.class);
+                }
+            }
+
+            var uploadBody = JacksonMapper.toMap(uploadResponse.getBody());
+            fileId = (String) uploadBody.get("name");
+        }
+
+        var payload = Map.of(
+            "messageId", UUID.randomUUID().toString(),
+            "contentMessage", Map.of(
+                "contentInfo", Map.of(
+                    "fileUrl", fileId
+                )
+            )
+        );
+
+        var endpointPath = "/v1/phones/" + java.net.URLEncoder.encode(rMsisdn, java.nio.charset.StandardCharsets.UTF_8) + "/agentMessages";
+        var response = this.executeRequest(
+            runContext,
+            endpointPath,
+            "POST",
+            HttpRequest.JsonRequestBody.builder().content(payload).build()
+        );
+
+        var responseBody = JacksonMapper.toMap(response.getBody());
+        var messageId = (String) responseBody.get("messageId");
+        var sendTimeStr = (String) responseBody.get("sendTime");
+        var sendTime = sendTimeStr != null ? Instant.parse(sendTimeStr) : Instant.now();
+
+        return Output.builder()
+            .messageId(messageId)
+            .sendTime(sendTime)
+            .build();
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(title = "The unique message ID assigned by the RBM platform")
+        private final String messageId;
+
+        @Schema(title = "The timestamp when the message was sent")
+        private final Instant sendTime;
+    }
+}

--- a/src/main/java/io/kestra/plugin/gcp/rcs/SendMessage.java
+++ b/src/main/java/io/kestra/plugin/gcp/rcs/SendMessage.java
@@ -51,7 +51,7 @@ public class SendMessage extends AbstractRcs implements RunnableTask<SendMessage
 
     @Schema(title = "The plain text content of the message")
     @NotNull
-    @PluginProperty
+    @PluginProperty(group = "main")
     private Property<String> text;
 
     @Override

--- a/src/main/java/io/kestra/plugin/gcp/rcs/SendMessage.java
+++ b/src/main/java/io/kestra/plugin/gcp/rcs/SendMessage.java
@@ -1,0 +1,97 @@
+package io.kestra.plugin.gcp.rcs;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+import io.kestra.core.http.HttpRequest;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.JacksonMapper;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode(callSuper = true)
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Send a plain text RCS message to a recipient's phone number",
+    description = "Sends a standard text message using Google RCS Business Messaging (RBM)."
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Send a plain text RCS message",
+            full = true,
+            code = """
+                id: rcs_send_message
+                namespace: company.team
+
+                tasks:
+                  - id: send
+                    type: io.kestra.plugin.gcp.rcs.SendMessage
+                    serviceAccount: "{{ secret('GCP_SERVICE_ACCOUNT') }}"
+                    agentId: "{{ secret('RBM_AGENT_ID') }}"
+                    msisdn: "+33612345678"
+                    text: "Your order has been shipped and will arrive within 2 business days."
+                """
+        )
+    }
+)
+public class SendMessage extends AbstractRcs implements RunnableTask<SendMessage.Output> {
+
+    @Schema(title = "The plain text content of the message")
+    @NotNull
+    @PluginProperty
+    private Property<String> text;
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+        var rMsisdn = runContext.render(this.msisdn).as(String.class).orElseThrow();
+        var rText = runContext.render(this.text).as(String.class).orElseThrow();
+
+        var payload = Map.of(
+            "messageId", UUID.randomUUID().toString(),
+            "contentMessage", Map.of(
+                "text", rText
+            )
+        );
+
+        var endpointPath = "/v1/phones/" + java.net.URLEncoder.encode(rMsisdn, java.nio.charset.StandardCharsets.UTF_8) + "/agentMessages";
+        var response = this.executeRequest(
+            runContext,
+            endpointPath,
+            "POST",
+            HttpRequest.JsonRequestBody.builder().content(payload).build()
+        );
+
+        var responseBody = JacksonMapper.toMap(response.getBody());
+        var messageId = (String) responseBody.get("messageId");
+        var sendTimeStr = (String) responseBody.get("sendTime");
+        var sendTime = sendTimeStr != null ? Instant.parse(sendTimeStr) : Instant.now();
+
+        return Output.builder()
+            .messageId(messageId)
+            .sendTime(sendTime)
+            .build();
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(title = "The unique message ID assigned by the RBM platform")
+        private final String messageId;
+
+        @Schema(title = "The timestamp when the message was sent")
+        private final Instant sendTime;
+    }
+}

--- a/src/main/java/io/kestra/plugin/gcp/rcs/SendRichCard.java
+++ b/src/main/java/io/kestra/plugin/gcp/rcs/SendRichCard.java
@@ -1,0 +1,151 @@
+package io.kestra.plugin.gcp.rcs;
+
+import java.time.Instant;
+import java.util.*;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.kestra.core.http.HttpRequest;
+import io.kestra.core.models.annotations.Example;
+import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.RunnableTask;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.serializers.JacksonMapper;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@ToString
+@EqualsAndHashCode(callSuper = true)
+@Getter
+@NoArgsConstructor
+@Schema(
+    title = "Send a standalone Rich Card to a recipient's phone number",
+    description = "Sends a rich media card with title, description, image, and action/reply buttons."
+)
+@Plugin(
+    examples = {
+        @Example(
+            title = "Send a Rich Card with action buttons",
+            full = true,
+            code = """
+                id: rcs_send_rich_card
+                namespace: company.team
+
+                tasks:
+                  - id: send_card
+                    type: io.kestra.plugin.gcp.rcs.SendRichCard
+                    serviceAccount: "{{ secret('GCP_SERVICE_ACCOUNT') }}"
+                    agentId: "{{ secret('RBM_AGENT_ID') }}"
+                    msisdn: "+33612345678"
+                    title: "Your delivery is ready"
+                    description: "Tap below to track your package or contact support."
+                    imageUrl: "https://example.com/delivery-banner.jpg"
+                    suggestions:
+                      - type: URL
+                        text: "Track package"
+                        url: "https://tracking.example.com/order/12345"
+                      - type: REPLY
+                        text: "Contact support"
+                        postbackData: "contact_support"
+                """
+        )
+    }
+)
+public class SendRichCard extends AbstractRcs implements RunnableTask<SendRichCard.Output> {
+
+    @Schema(title = "The card title")
+    @PluginProperty
+    private Property<String> title;
+
+    @JsonProperty("description")
+    @Schema(name = "description", title = "The card description")
+    @PluginProperty
+    private Property<String> contentDescription;
+
+    @Schema(title = "The card image URL")
+    @PluginProperty
+    private Property<String> imageUrl;
+
+    @Schema(title = "The list of suggested action/reply buttons (max 4)")
+    @PluginProperty
+    private List<Suggestion> suggestions;
+
+    @Override
+    public Output run(RunContext runContext) throws Exception {
+        var rMsisdn = runContext.render(this.msisdn).as(String.class).orElseThrow();
+
+        var cardContent = new HashMap<String, Object>();
+        if (this.title != null) {
+            runContext.render(this.title).as(String.class).ifPresent(t -> cardContent.put("title", t));
+        }
+        if (this.contentDescription != null) {
+            runContext.render(this.contentDescription).as(String.class).ifPresent(d -> cardContent.put("description", d));
+        }
+        if (this.imageUrl != null) {
+            var rImageUrl = runContext.render(this.imageUrl).as(String.class).orElse(null);
+            if (rImageUrl != null) {
+                cardContent.put(
+                    "media", Map.of(
+                        "height", "MEDIUM",
+                        "contentInfo", Map.of("fileUrl", rImageUrl)
+                    )
+                );
+            }
+        }
+        if (this.suggestions != null && !this.suggestions.isEmpty()) {
+            if (this.suggestions.size() > 4) {
+                throw new IllegalArgumentException("RCS Standalone Card suggestions cannot exceed 4 items");
+            }
+            var rbmSuggestions = new ArrayList<Map<String, Object>>();
+            for (var s : this.suggestions) {
+                rbmSuggestions.add(s.toRbmSuggestion(runContext));
+            }
+            cardContent.put("suggestions", rbmSuggestions);
+        }
+
+        var payload = Map.of(
+            "messageId", UUID.randomUUID().toString(),
+            "contentMessage", Map.of(
+                "richCard", Map.of(
+                    "standaloneCard", Map.of(
+                        "cardOrientation", "VERTICAL",
+                        "cardContent", cardContent
+                    )
+                )
+            )
+        );
+
+        var endpointPath = "/v1/phones/" + java.net.URLEncoder.encode(rMsisdn, java.nio.charset.StandardCharsets.UTF_8) + "/agentMessages";
+        var response = this.executeRequest(
+            runContext,
+            endpointPath,
+            "POST",
+            HttpRequest.JsonRequestBody.builder().content(payload).build()
+        );
+
+        var responseBody = JacksonMapper.toMap(response.getBody());
+        var messageId = (String) responseBody.get("messageId");
+        var sendTimeStr = (String) responseBody.get("sendTime");
+        var sendTime = sendTimeStr != null ? Instant.parse(sendTimeStr) : Instant.now();
+
+        return Output.builder()
+            .messageId(messageId)
+            .sendTime(sendTime)
+            .build();
+    }
+
+    @Builder
+    @Getter
+    public static class Output implements io.kestra.core.models.tasks.Output {
+        @Schema(title = "The unique message ID assigned by the RBM platform")
+        private final String messageId;
+
+        @Schema(title = "The timestamp when the message was sent")
+        private final Instant sendTime;
+    }
+}

--- a/src/main/java/io/kestra/plugin/gcp/rcs/SendRichCard.java
+++ b/src/main/java/io/kestra/plugin/gcp/rcs/SendRichCard.java
@@ -59,20 +59,20 @@ import lombok.experimental.SuperBuilder;
 public class SendRichCard extends AbstractRcs implements RunnableTask<SendRichCard.Output> {
 
     @Schema(title = "The card title")
-    @PluginProperty
+    @PluginProperty(group = "main")
     private Property<String> title;
 
     @JsonProperty("description")
     @Schema(name = "description", title = "The card description")
-    @PluginProperty
+    @PluginProperty(group = "main")
     private Property<String> contentDescription;
 
     @Schema(title = "The card image URL")
-    @PluginProperty
+    @PluginProperty(group = "main")
     private Property<String> imageUrl;
 
     @Schema(title = "The list of suggested action/reply buttons (max 4)")
-    @PluginProperty
+    @PluginProperty(group = "main")
     private List<Suggestion> suggestions;
 
     @Override

--- a/src/main/java/io/kestra/plugin/gcp/rcs/Suggestion.java
+++ b/src/main/java/io/kestra/plugin/gcp/rcs/Suggestion.java
@@ -1,0 +1,92 @@
+package io.kestra.plugin.gcp.rcs;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.kestra.core.models.annotations.PluginProperty;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+import lombok.extern.jackson.Jacksonized;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Jacksonized
+public class Suggestion {
+
+    @Schema(title = "The type of suggestion button (URL, DIAL, REPLY, MAP)")
+    @NotNull
+    @PluginProperty
+    private Property<SuggestionType> type;
+
+    @Schema(title = "The label text displayed on the suggestion button")
+    @NotNull
+    @PluginProperty
+    private Property<String> text;
+
+    @Schema(title = "The postback data payload returned to the agent when clicked")
+    @PluginProperty
+    private Property<String> postbackData;
+
+    @Schema(title = "The destination URL (required if type is URL)")
+    @PluginProperty
+    private Property<String> url;
+
+    @Schema(title = "The phone number to dial in E.164 format (required if type is DIAL)")
+    @PluginProperty
+    private Property<String> phoneNumber;
+
+    @Schema(title = "The latitude for the location coordinates (required if type is MAP)")
+    @PluginProperty
+    private Property<Double> latitude;
+
+    @Schema(title = "The longitude for the location coordinates (required if type is MAP)")
+    @PluginProperty
+    private Property<Double> longitude;
+
+    @Schema(title = "The label description for the location (optional if type is MAP)")
+    @PluginProperty
+    private Property<String> locationLabel;
+
+    public Map<String, Object> toRbmSuggestion(RunContext runContext) throws Exception {
+        var rType = runContext.render(this.type).as(SuggestionType.class).orElseThrow();
+        var rText = runContext.render(this.text).as(String.class).orElseThrow();
+        var rPostback = runContext.render(this.postbackData).as(String.class).orElse(rText);
+
+        if (rType == SuggestionType.REPLY) {
+            return Map.of(
+                "reply", Map.of(
+                    "text", rText,
+                    "postbackData", rPostback
+                )
+            );
+        }
+
+        var actionContent = new HashMap<String, Object>();
+        actionContent.put("text", rText);
+        actionContent.put("postbackData", rPostback);
+
+        if (rType == SuggestionType.URL) {
+            var rUrl = runContext.render(this.url).as(String.class).orElseThrow();
+            actionContent.put("openUrlAction", Map.of("url", rUrl));
+        } else if (rType == SuggestionType.DIAL) {
+            var rPhone = runContext.render(this.phoneNumber).as(String.class).orElseThrow();
+            actionContent.put("dialAction", Map.of("phoneNumber", rPhone));
+        } else if (rType == SuggestionType.MAP) {
+            var rLat = runContext.render(this.latitude).as(Double.class).orElseThrow();
+            var rLng = runContext.render(this.longitude).as(Double.class).orElseThrow();
+            var location = new HashMap<String, Object>();
+            location.put("latitude", rLat);
+            location.put("longitude", rLng);
+            runContext.render(this.locationLabel).as(String.class).ifPresent(l -> location.put("label", l));
+            actionContent.put("viewLocationAction", Map.of("location", location));
+        }
+
+        return Map.of("action", actionContent);
+    }
+}

--- a/src/main/java/io/kestra/plugin/gcp/rcs/SuggestionType.java
+++ b/src/main/java/io/kestra/plugin/gcp/rcs/SuggestionType.java
@@ -1,0 +1,11 @@
+package io.kestra.plugin.gcp.rcs;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(title = "The action type for the suggestion button")
+public enum SuggestionType {
+    URL,
+    DIAL,
+    REPLY,
+    MAP
+}

--- a/src/main/java/io/kestra/plugin/gcp/rcs/package-info.java
+++ b/src/main/java/io/kestra/plugin/gcp/rcs/package-info.java
@@ -1,0 +1,8 @@
+@PluginSubGroup(
+    title = "RCS",
+    description = "This sub-group of plugins contains tasks for Google RCS Business Messaging.",
+    categories = { PluginSubGroup.PluginCategory.CLOUD }
+)
+package io.kestra.plugin.gcp.rcs;
+
+import io.kestra.core.models.annotations.PluginSubGroup;

--- a/src/main/resources/doc/io.kestra.plugin.gcp.rcs.md
+++ b/src/main/resources/doc/io.kestra.plugin.gcp.rcs.md
@@ -1,0 +1,36 @@
+# How to use the Google Cloud RCS plugin
+
+Google Cloud Rich Communication Services (RCS) plugin for Business Messaging enables Kestra workflows to send Rich Communication Services (RCS) messages via Google RCS Business Messaging (RBM).
+
+This sub-package provides tasks to send rich interactive messages — plain text, Rich Cards with images and action buttons, carousels, and file attachments — to end users directly from orchestrated workflows.
+
+## Authentication
+
+All tasks inherit GCP authentication properties from the common GCP plugin structure. You can authenticate using:
+- A service account JSON key via the `serviceAccount` property.
+- Environment-provided credentials (e.g. `GOOGLE_APPLICATION_CREDENTIALS` environment variable).
+- Metadata-service-provided IAM credentials when running inside Google Cloud (GKE, GCE, etc.).
+
+Authentication requires `roles/rcsbusinessmessaging.admin` configured on the Brand Agent.
+
+## Tasks
+
+### SendMessage
+Sends a plain text RCS message to a recipient's phone number (MSISDN).
+- `text`: The plain text content of the message.
+
+### SendRichCard
+Sends a standalone Rich Card to a recipient's phone number (MSISDN).
+- `title`: The card title.
+- `description`: The card description.
+- `imageUrl`: The card media/image URL.
+- `suggestions`: The list of suggested action/reply buttons (max 4).
+
+### SendCarousel
+Sends a carousel of 2–10 Rich Cards; useful for product lists, menu options, or step-by-step instructions.
+- `cards`: The list of rich cards in the carousel (between 2 and 10 cards).
+
+### SendFile
+Sends a file attachment (image, video, audio, or PDF) to a recipient's phone number.
+- `file`: The file attachment URI (can be a public HTTPS URL or a Kestra internal storage URI).
+- `thumbnail`: Optional thumbnail image URI.

--- a/src/main/resources/icons/io.kestra.plugin.gcp.rcs.svg
+++ b/src/main/resources/icons/io.kestra.plugin.gcp.rcs.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24px" height="24px" viewBox="0 0 24 24">
+  <g fill="none" stroke="#4285F4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M21 11.5a8.38 8.38 0 0 1-.9 3.8 8.5 8.5 0 0 1-7.6 4.7 8.38 8.38 0 0 1-3.8-.9L3 21l1.9-5.7a8.38 8.38 0 0 1-.9-3.8 8.5 8.5 0 0 1 4.7-7.6 8.38 8.38 0 0 1 3.8-.9h.5a8.48 8.48 0 0 1 8 8v.5z"/>
+  </g>
+</svg>

--- a/src/main/resources/metadata/rcs.yaml
+++ b/src/main/resources/metadata/rcs.yaml
@@ -1,0 +1,8 @@
+group: io.kestra.plugin.gcp.rcs
+name: rcs
+title: Google Cloud RCS
+description: "Send Rich Communication Services (RCS) messages using Google RCS Business Messaging (RBM)."
+body: "Use these tasks to send plain text, rich cards, carousels, and file attachments directly to recipient phone numbers. Authentication is integrated with GCP service accounts (CredentialService)."
+videos: []
+createdBy: "Kestra Core Team"
+managedBy: "Kestra Core Team"

--- a/src/test/java/io/kestra/plugin/gcp/rcs/RcsTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/rcs/RcsTest.java
@@ -46,6 +46,7 @@ public class RcsTest {
 
         Mockito.doReturn(scopedCredentials).when(mockCredentials).createScoped(Mockito.any(List.class));
         Mockito.doReturn(mockToken).when(scopedCredentials).refreshAccessToken();
+        Mockito.doReturn(mockToken).when(mockCredentials).refreshAccessToken();
         return mockCredentials;
     }
 

--- a/src/test/java/io/kestra/plugin/gcp/rcs/RcsTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/rcs/RcsTest.java
@@ -1,0 +1,287 @@
+package io.kestra.plugin.gcp.rcs;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.collect.ImmutableMap;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.storages.StorageInterface;
+import io.kestra.core.tenant.TenantService;
+import io.kestra.core.utils.TestsUtils;
+
+import jakarta.inject.Inject;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+@KestraTest
+@WireMockTest
+public class RcsTest {
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Inject
+    private StorageInterface storageInterface;
+
+    private GoogleCredentials mockCredentials() throws Exception {
+        var mockCredentials = Mockito.mock(GoogleCredentials.class);
+        var scopedCredentials = Mockito.mock(GoogleCredentials.class);
+        var mockToken = new AccessToken("mock-oauth-token", new Date(System.currentTimeMillis() + 3600000));
+
+        Mockito.doReturn(scopedCredentials).when(mockCredentials).createScoped(Mockito.any(List.class));
+        Mockito.doReturn(mockToken).when(scopedCredentials).refreshAccessToken();
+        return mockCredentials;
+    }
+
+    private void stubRbmEndpoints() {
+        stubFor(
+            post(urlPathMatching("/v1/phones/[^/]+/agentMessages"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "name": "phones/+33612345678/agentMessages/msg-123",
+                              "messageId": "msg-123",
+                              "sendTime": "2026-07-10T14:33:53Z"
+                            }
+                            """)
+                )
+        );
+
+        stubFor(
+            post(urlPathMatching("/v1/files"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "name": "files/file-123",
+                              "mimeType": "application/pdf"
+                            }
+                            """)
+                )
+        );
+
+        stubFor(
+            post(urlPathMatching("/upload/v1/files"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "name": "files/file-binary-123",
+                              "mimeType": "application/octet-stream"
+                            }
+                            """)
+                )
+        );
+    }
+
+    @Test
+    void sendMessage(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubRbmEndpoints();
+
+        var task = SendMessage.builder()
+            .id(RcsTest.class.getSimpleName())
+            .type(SendMessage.class.getName())
+            .baseUrl(wmRuntimeInfo.getHttpBaseUrl())
+            .agentId(Property.ofValue("agent-123"))
+            .msisdn(Property.ofValue("+33612345678"))
+            .text(Property.ofValue("Your order has been shipped."))
+            .build();
+
+        var spyTask = Mockito.spy(task);
+        Mockito.doReturn(mockCredentials()).when(spyTask).credentials(Mockito.any(RunContext.class));
+
+        var runContext = TestsUtils.mockRunContext(runContextFactory, spyTask, ImmutableMap.of());
+        var output = spyTask.run(runContext);
+
+        assertThat(output.getMessageId(), is("msg-123"));
+        assertThat(output.getSendTime(), is(Instant.parse("2026-07-10T14:33:53Z")));
+
+        verify(
+            postRequestedFor(urlPathEqualTo("/v1/phones/%2B33612345678/agentMessages"))
+                .withQueryParam("agentId", equalTo("agent-123"))
+                .withHeader("Content-Type", equalTo("application/json"))
+                .withRequestBody(containing("Your order has been shipped."))
+        );
+    }
+
+    @Test
+    void sendRichCard(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubRbmEndpoints();
+
+        var task = SendRichCard.builder()
+            .id(RcsTest.class.getSimpleName())
+            .type(SendRichCard.class.getName())
+            .baseUrl(wmRuntimeInfo.getHttpBaseUrl())
+            .agentId(Property.ofValue("agent-123"))
+            .msisdn(Property.ofValue("+33612345678"))
+            .title(Property.ofValue("Delivery Alert"))
+            .contentDescription(Property.ofValue("Your package is ready."))
+            .imageUrl(Property.ofValue("https://example.com/banner.jpg"))
+            .suggestions(
+                List.of(
+                    Suggestion.builder()
+                        .type(Property.ofValue(SuggestionType.URL))
+                        .text(Property.ofValue("Track"))
+                        .url(Property.ofValue("https://tracking.com"))
+                        .build(),
+                    Suggestion.builder()
+                        .type(Property.ofValue(SuggestionType.REPLY))
+                        .text(Property.ofValue("Confirm"))
+                        .postbackData(Property.ofValue("confirm_data"))
+                        .build()
+                )
+            )
+            .build();
+
+        var spyTask = Mockito.spy(task);
+        Mockito.doReturn(mockCredentials()).when(spyTask).credentials(Mockito.any(RunContext.class));
+
+        var runContext = TestsUtils.mockRunContext(runContextFactory, spyTask, ImmutableMap.of());
+        var output = spyTask.run(runContext);
+
+        assertThat(output.getMessageId(), is("msg-123"));
+
+        verify(
+            postRequestedFor(urlPathEqualTo("/v1/phones/%2B33612345678/agentMessages"))
+                .withRequestBody(containing("Delivery Alert"))
+                .withRequestBody(containing("Track"))
+                .withRequestBody(containing("confirm_data"))
+        );
+    }
+
+    @Test
+    void sendCarousel(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubRbmEndpoints();
+
+        var task = SendCarousel.builder()
+            .id(RcsTest.class.getSimpleName())
+            .type(SendCarousel.class.getName())
+            .baseUrl(wmRuntimeInfo.getHttpBaseUrl())
+            .agentId(Property.ofValue("agent-123"))
+            .msisdn(Property.ofValue("+33612345678"))
+            .cards(
+                List.of(
+                    Card.builder()
+                        .title(Property.ofValue("Card 1"))
+                        .description(Property.ofValue("Description 1"))
+                        .imageUrl(Property.ofValue("https://example.com/c1.jpg"))
+                        .build(),
+                    Card.builder()
+                        .title(Property.ofValue("Card 2"))
+                        .description(Property.ofValue("Description 2"))
+                        .imageUrl(Property.ofValue("https://example.com/c2.jpg"))
+                        .build()
+                )
+            )
+            .build();
+
+        var spyTask = Mockito.spy(task);
+        Mockito.doReturn(mockCredentials()).when(spyTask).credentials(Mockito.any(RunContext.class));
+
+        var runContext = TestsUtils.mockRunContext(runContextFactory, spyTask, ImmutableMap.of());
+        var output = spyTask.run(runContext);
+
+        assertThat(output.getMessageId(), is("msg-123"));
+
+        verify(
+            postRequestedFor(urlPathEqualTo("/v1/phones/%2B33612345678/agentMessages"))
+                .withRequestBody(containing("Card 1"))
+                .withRequestBody(containing("Card 2"))
+        );
+    }
+
+    @Test
+    void sendFileFromUrl(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubRbmEndpoints();
+
+        var task = SendFile.builder()
+            .id(RcsTest.class.getSimpleName())
+            .type(SendFile.class.getName())
+            .baseUrl(wmRuntimeInfo.getHttpBaseUrl())
+            .agentId(Property.ofValue("agent-123"))
+            .msisdn(Property.ofValue("+33612345678"))
+            .file(Property.ofValue("https://example.com/file.pdf"))
+            .build();
+
+        var spyTask = Mockito.spy(task);
+        Mockito.doReturn(mockCredentials()).when(spyTask).credentials(Mockito.any(RunContext.class));
+
+        var runContext = TestsUtils.mockRunContext(runContextFactory, spyTask, ImmutableMap.of());
+        var output = spyTask.run(runContext);
+
+        assertThat(output.getMessageId(), is("msg-123"));
+
+        verify(
+            postRequestedFor(urlPathEqualTo("/v1/files"))
+                .withRequestBody(containing("https://example.com/file.pdf"))
+        );
+
+        verify(
+            postRequestedFor(urlPathEqualTo("/v1/phones/%2B33612345678/agentMessages"))
+                .withRequestBody(containing("files/file-123"))
+        );
+    }
+
+    @Test
+    void sendFileFromStorage(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        stubRbmEndpoints();
+
+        var storageUri = storageInterface.put(
+            TenantService.MAIN_TENANT,
+            null,
+            new URI("/test-attachment.pdf"),
+            new ByteArrayInputStream("dummy pdf content".getBytes())
+        );
+
+        var task = SendFile.builder()
+            .id(RcsTest.class.getSimpleName())
+            .type(SendFile.class.getName())
+            .baseUrl(wmRuntimeInfo.getHttpBaseUrl())
+            .agentId(Property.ofValue("agent-123"))
+            .msisdn(Property.ofValue("+33612345678"))
+            .file(Property.ofValue(storageUri.toString()))
+            .build();
+
+        var spyTask = Mockito.spy(task);
+        Mockito.doReturn(mockCredentials()).when(spyTask).credentials(Mockito.any(RunContext.class));
+
+        var runContext = TestsUtils.mockRunContext(runContextFactory, spyTask, ImmutableMap.of());
+        var output = spyTask.run(runContext);
+
+        assertThat(output.getMessageId(), is("msg-123"));
+
+        verify(
+            postRequestedFor(urlPathEqualTo("/upload/v1/files"))
+                .withHeader("Content-Type", equalTo("application/pdf"))
+                .withRequestBody(equalTo("dummy pdf content"))
+        );
+
+        verify(
+            postRequestedFor(urlPathEqualTo("/v1/phones/%2B33612345678/agentMessages"))
+                .withRequestBody(containing("files/file-binary-123"))
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implements the `rcs` sub-plugin under `io.kestra.plugin.gcp.rcs` enabling Kestra workflows to send Rich Communication Services (RCS) messages via Google RCS Business Messaging (RBM).
Teams can send rich interactive messages — plain text, Rich Cards with images and action buttons, carousels, and file attachments — to end users directly from orchestrated flows, enabling automated notifications, alerts, and conversational workflow hand-offs.

## Tasks & Triggers Added

| Class | Description |
|---|---|
| `AbstractRcs` | Abstract base managing GCP connection and RBM authentication parameters (`agentId`, `msisdn`, `scopes`, `baseUrl` via `CredentialService`) |
| `SendMessage` | Sends a plain text RCS message to a recipient's phone number (MSISDN) |
| `SendRichCard` | Sends a standalone Rich Card containing media, titles, descriptions, and up to 4 suggested URL/DIAL/REPLY/MAP action buttons |
| `SendCarousel` | Sends a horizontal carousel of 2–10 Rich Cards to display multi-option lists or step-by-step instructions |
| `SendFile` | Sends a file attachment (images, videos, audio, PDFs) using public HTTPS URLs or files fetched directly from Kestra internal storage |

## Plugin Structure

- Package: `io.kestra.plugin.gcp.rcs`
- `package-info.java` with `@PluginSubGroup(categories = {PluginSubGroup.PluginCategory.CLOUD})`
- `metadata/rcs.yaml` and `io.kestra.plugin.gcp.rcs.svg` added
- `doc/io.kestra.plugin.gcp.rcs.md` added
- `AGENTS.md` updated with new task class names

## Coding Standards Met

- [x] All properties use `Property<T>` — no legacy `@PluginProperty(dynamic = true)`
- [x] Secret/credential properties annotated with `@PluginProperty(secret = true)`
- [x] Every property and output annotated with `@Schema` (without trailing periods in titles)
- [x] Five Lombok annotations on all task classes (`@SuperBuilder`, `@ToString`, `@EqualsAndHashCode`, `@Getter`, `@NoArgsConstructor`)
- [x] Logging via `runContext.logger()` only
- [x] JSON serialization via Jackson mappers from `io.kestra.core.serializers`
- [x] GCP auth via `CredentialService` (same pattern as `bigquery`, `gcs`)
- [x] `@Plugin(examples = ...)` entries with `full = true` and `{{ secret(...) }}` for sensitive values
- [x] Clean files with absolutely zero comments in code
- [x] Java 21 `var` variable type standards met

## Gradle Dependency Added

*No additional external dependencies required.*

## Testing

- [x] `./gradlew build` passes
- [x] `./gradlew test` passes (5 Wiremock unit tests covering text, card, carousel, file from URL, and file from storage messaging channels)
- Manual QA validated against real Kestra instance using shadow jar + Docker

## Related

Closes part of EPIC #622
Coses https://github.com/kestra-io/plugin-gcp/issues/623