### PR TITLE
fix: resolve GCloudCLI credential path via task runner working dir

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/cli/GCloudCLI.java
+++ b/src/main/java/io/kestra/plugin/gcp/cli/GCloudCLI.java
@@ -12,6 +12,7 @@ import io.kestra.core.models.annotations.Plugin;
 import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.*;
+import io.kestra.core.models.tasks.runners.TargetOS;
 import io.kestra.core.models.tasks.runners.TaskRunner;
 import io.kestra.core.runners.RunContext;
 import io.kestra.plugin.scripts.exec.scripts.models.DockerOptions;
@@ -194,12 +195,13 @@ public class GCloudCLI extends Task implements RunnableTask<ScriptOutput>, Names
             .withContainerImage(runContext.render(this.containerImage).as(String.class).orElseThrow())
             .withInterpreter(Property.ofValue(List.of("/bin/sh", "-c")))
             .withCommands(this.commands)
-            .withEnv(this.getEnv(runContext))
             .withNamespaceFiles(namespaceFiles)
             .withInputFiles(inputFiles)
             .withOutputFiles(renderedOutputFiles.isEmpty() ? null : renderedOutputFiles);
 
-        return commands.run();
+        return commands
+            .addEnv(this.getEnv(runContext, commands))
+            .run();
     }
 
     private DockerOptions injectDefaults(DockerOptions original) {
@@ -215,15 +217,21 @@ public class GCloudCLI extends Task implements RunnableTask<ScriptOutput>, Names
         return builder.build();
     }
 
-    private Map<String, String> getEnv(RunContext runContext) throws IOException, IllegalVariableEvaluationException {
+    private Map<String, String> getEnv(RunContext runContext, CommandsWrapper commands) throws IOException, IllegalVariableEvaluationException {
         Map<String, String> envs = new HashMap<>();
 
         if (serviceAccount != null) {
             Path serviceAccountPath = runContext.workingDir().createTempFile(runContext.render(this.serviceAccount).as(String.class).orElseThrow().getBytes());
+
+            // Remap the worker-absolute temp path to the runner working dir (e.g. /kestra/working-dir on
+            // Kubernetes) so gcloud finds the key inside the container; on Docker it resolves unchanged.
+            String relativePath = runContext.workingDir().path().relativize(serviceAccountPath).toString();
+            String credentialPath = commands.getTaskRunner().toAbsolutePath(runContext, commands, relativePath, TargetOS.LINUX);
+
             envs.putAll(
                 Map.of(
-                    "GOOGLE_APPLICATION_CREDENTIALS", serviceAccountPath.toString(),
-                    "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE", serviceAccountPath.toString()
+                    "GOOGLE_APPLICATION_CREDENTIALS", credentialPath,
+                    "CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE", credentialPath
                 )
             );
         }


### PR DESCRIPTION
GCloudCLI writes the service account key to a temp file in the working dir but exposed the worker-side absolute path in GOOGLE_APPLICATION_CREDENTIALS / CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE. 
That path only resolves when the runner bind-mounts the working dir at the same path (Docker). On the Kubernetes runner the working dir is remapped to /kestra/working-dir, so gcloud couldn't find the key and authentication failed.

The path now goes through taskRunner.toAbsolutePath(), the same approach the script plugins already use (e.g. Python PYTHONPATH). Docker behavior is unchanged; the Kubernetes runner is fixed.


edit: I didnt add test because I do not know how I should test within a K8S runner context, if you have any example I'll try to write one