### PR TITLE
docs: some doc fixes

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/auth/OauthAccessToken.java
+++ b/src/main/java/io/kestra/plugin/gcp/auth/OauthAccessToken.java
@@ -65,7 +65,7 @@ public class OauthAccessToken extends AbstractTask implements RunnableTask<Oauth
     @Getter
     public static class Output implements io.kestra.core.models.tasks.Output {
         @NotNull
-        @Schema(title = "An OAuth access token for the current user")
+        @Schema(title = "An OAuth access token for the configured service account")
         private final AccessTokenOutput accessToken;
     }
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
@@ -48,7 +48,7 @@ abstract public class AbstractBigquery extends AbstractTask implements WorkerJob
 
     @Schema(
         title = "Automatic BigQuery retry policy",
-        description = "Optional custom retry policy for retryable BigQuery errors. If unset, uses an exponential backoff starting at 5s, up to 15m, max 10 attempts."
+        description = "Optional custom retry policy for retryable BigQuery errors. If unset, uses an exponential backoff starting at 5s (per-attempt interval capped at 60m), with a total duration of up to 15m and a maximum of 10 attempts."
     )
     @PluginProperty(group = "advanced")
     protected AbstractRetry retryAuto;

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractLoad.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractLoad.java
@@ -294,7 +294,7 @@ abstract public class AbstractLoad extends AbstractBigquery implements RunnableT
     public static class CsvOptions {
         @Schema(
             title = "Whether BigQuery should accept rows that are missing trailing optional columns",
-            description = "If true, BigQuery treats missing trailing columns as null values. If {@code false}, records" +
+            description = "If true, BigQuery treats missing trailing columns as null values. If false, records" +
                 " with missing trailing columns are treated as bad records, and if there are too many bad" +
                 " records, an invalid error is returned in the job result. By default, rows with missing" +
                 " trailing columns are considered bad records."
@@ -313,7 +313,7 @@ abstract public class AbstractLoad extends AbstractBigquery implements RunnableT
             title = "The character encoding of the data",
             description = "The supported values are UTF-8 or ISO-8859-1. The" +
                 " default value is UTF-8. BigQuery decodes the data after the raw, binary data has been split" +
-                " using the values set in {@link #setQuote(String)} and {@link #setFieldDelimiter(String)}."
+                " using the values set in the `quote` and `fieldDelimiter` properties."
         )
         @PluginProperty(group = "processing")
         private Property<String> encoding;
@@ -334,8 +334,8 @@ abstract public class AbstractLoad extends AbstractBigquery implements RunnableT
                 " string to ISO-8859-1 encoding, and then uses the first byte of the encoded string to split" +
                 " the data in its raw, binary state. The default value is a double-quote ('\"'). If your data" +
                 " does not contain quoted sections, set the property value to an empty string. If your data" +
-                " contains quoted newline characters, you must also set {@link" +
-                " #setAllowQuotedNewLines(boolean)} property to {@code true}."
+                " contains quoted newline characters, you must also set the `allowQuotedNewLines`" +
+                " property to true."
         )
         @PluginProperty(group = "advanced")
         private Property<String> quote;

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractTableCreateUpdate.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractTableCreateUpdate.java
@@ -29,7 +29,7 @@ import lombok.experimental.SuperBuilder;
 abstract public class AbstractTableCreateUpdate extends AbstractTable {
     @Schema(
         title = "Table definition",
-        description = "Required table definition (standard, external, view, etc.)"
+        description = "The table definition (standard, external, view, etc.). Required when creating a table; optional when updating, where the current definition is preserved unless overridden."
     )
     @PluginProperty(group = "advanced")
     protected TableDefinition tableDefinition;

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/CopyPartitions.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/CopyPartitions.java
@@ -234,6 +234,7 @@ public class CopyPartitions extends AbstractPartition implements RunnableTask<Co
                 .datasetId(table.getDataset())
                 .table(table.getTable())
                 .partitions(partitions)
+                .jobId(jobId)
                 .build();
         }
     }

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/CreateDataset.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/CreateDataset.java
@@ -31,7 +31,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 @Plugin(
     examples = {
         @Example(
-            title = "Create a dataset if not exits",
+            title = "Create a dataset if not exists",
             full = true,
             code = """
                 id: gcp_bq_create_dataset

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Load.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Load.java
@@ -36,7 +36,7 @@ import lombok.experimental.SuperBuilder;
 @Plugin(
     examples = {
         @Example(
-            title = "Load an csv file from an input file",
+            title = "Load a CSV file from an input file",
             full = true,
             code = """
                 id: gcp_bq_load

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/LoadFromGcs.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/LoadFromGcs.java
@@ -70,10 +70,15 @@ import io.kestra.core.models.annotations.PluginProperty;
                         ]
                       }
 
+                  - id: upload_to_gcs
+                    type: io.kestra.plugin.gcp.gcs.Upload
+                    from: "{{ outputs.ion_to_avro.uri }}"
+                    to: "gs://my-bucket/orders.avro"
+
                   - id: load_from_gcs
                     type: io.kestra.plugin.gcp.bigquery.LoadFromGcs
                     from:
-                      - "{{ outputs.ion_to_avro.uri }}"
+                      - "{{ outputs.upload_to_gcs.uri }}"
                     destinationTable: "my-project.my_dataset.my_table"
                     format: AVRO
                     avroOptions:

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
@@ -92,7 +92,7 @@ import reactor.core.publisher.Mono;
                 tasks:
                   - id: fetch
                     type: io.kestra.plugin.gcp.bigquery.Query
-                    fetch: true
+                    fetchType: FETCH
                     sql: |
                       SELECT 1 as id, "John" as name
                       UNION ALL
@@ -114,7 +114,7 @@ import reactor.core.publisher.Mono;
         @Metric(name = "total.bytes.processed", type = Counter.TYPE, unit = "bytes", description = "The total number of bytes processed by the query."),
         @Metric(
             name = "total.partitions.processed", type = Counter.TYPE, unit = "partitions",
-            description = "The totla number of partitions processed from all partitioned tables referenced in the job."
+            description = "The total number of partitions processed from all partitioned tables referenced in the job."
         ),
         @Metric(name = "total.slot.ms", type = Counter.TYPE, description = "The slot-milliseconds consumed by the query."),
         @Metric(
@@ -123,6 +123,8 @@ import reactor.core.publisher.Mono;
         ),
         @Metric(name = "referenced.tables", type = Counter.TYPE, description = "The number of tables referenced by the query."),
         @Metric(name = "num.child.jobs", type = Counter.TYPE, description = "The number of child jobs executed by the query."),
+        @Metric(name = "total.rows", type = Counter.TYPE, unit = "records", description = "The total number of rows returned by the query."),
+        @Metric(name = "fetch.rows", type = Counter.TYPE, unit = "records", description = "The number of rows fetched into the task output."),
     }
 )
 @Schema(
@@ -264,8 +266,7 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
 
     @Schema(
         title = "Sets whether to use BigQuery's legacy SQL dialect for this query",
-        description = " A valid query will return a mostly empty response with some processing statistics, " +
-            "while an invalid query will return the same error it would if it wasn't a dry run."
+        description = "If true, uses BigQuery's legacy SQL dialect for this query instead of the default standard SQL dialect."
     )
     @Builder.Default
     @PluginProperty(group = "advanced")
@@ -532,13 +533,13 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
 
         @Schema(
             title = "List containing the fetched data",
-            description = "Only populated if 'fetch' parameter is set to true."
+            description = "Only populated if `fetchType` is `FETCH`."
         )
         private List<Map<String, Object>> rows;
 
         @Schema(
             title = "Map containing the first row of fetched data",
-            description = "Only populated if 'fetchOne' parameter is set to true."
+            description = "Only populated if `fetchType` is `FETCH_ONE`."
         )
         private Map<String, Object> row;
 
@@ -549,7 +550,7 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
 
         @Schema(
             title = "The uri of store result",
-            description = "Only populated if 'store' is set to true."
+            description = "Only populated if `fetchType` is `STORE`."
         )
         private URI uri;
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/StorageWrite.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/StorageWrite.java
@@ -81,7 +81,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 )
 @Schema(
     title = "Stream a file to BigQuery via Storage Write API",
-    description = "Reads a file from Kestra internal storage and writes rows with the BigQuery Storage Write API. Supports DEFAULT or PENDING streams (commit required for PENDING). Requires the destination table to exist."
+    description = "Reads a file from Kestra internal storage and writes rows with the BigQuery Storage Write API. Supports DEFAULT, COMMITTED, or PENDING streams (commit required for PENDING). Requires the destination table to exist."
 )
 public class StorageWrite extends AbstractTask implements RunnableTask<StorageWrite.Output> {
     private static final int MAX_IN_FLIGHT_APPENDS = 20;

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Trigger.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Trigger.java
@@ -52,7 +52,7 @@ import io.kestra.core.models.annotations.PluginProperty;
                     type: io.kestra.plugin.gcp.bigquery.Trigger
                     interval: "PT5M"
                     sql: "SELECT * FROM `myproject.mydataset.mytable`"
-                    fetch: true
+                    fetchType: FETCH
                 """
         )
     }

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/models/EncryptionConfiguration.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/models/EncryptionConfiguration.java
@@ -15,7 +15,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 @Jacksonized
 public class EncryptionConfiguration {
     @Schema(
-        name = "The KMS key name."
+        title = "The KMS key name."
     )
     @PluginProperty(group = "advanced")
     private final Property<String> kmsKeyName;

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/models/ExternalTableDefinition.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/models/ExternalTableDefinition.java
@@ -20,10 +20,9 @@ import io.kestra.core.models.annotations.PluginProperty;
 public class ExternalTableDefinition {
     @Schema(
         title = "The fully-qualified URIs that point to your data in Google Cloud Storage",
-        description = "Each URI can\n" +
-            "* contain one '*' wildcard character that must come after the bucket's name. Size limits related\n" +
-            "* to load jobs apply to external data sources, plus an additional limit of 10 GB maximum size\n" +
-            "* across all URIs."
+        description = "Each URI can contain one '*' wildcard character that must come after the bucket's name. " +
+            "Size limits related to load jobs apply to external data sources, plus an additional limit of 10 GB " +
+            "maximum size across all URIs."
     )
     @PluginProperty(group = "advanced")
     private final Property<List<String>> sourceUris;

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/models/Field.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/models/Field.java
@@ -35,7 +35,7 @@ public class Field {
     private final Property<StandardSQLTypeName> type;
 
     @Schema(
-        title = "The list of sub-fields if `type` is a `LegacySQLType.RECORD`. Returns null otherwise"
+        title = "The list of sub-fields if `type` is a record/struct type (`StandardSQLTypeName.STRUCT`). Null otherwise."
     )
     @PluginProperty(group = "advanced")
     private final List<Field> subFields;

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/models/MaterializedViewDefinition.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/models/MaterializedViewDefinition.java
@@ -17,7 +17,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 @Builder
 @Jacksonized
 public class MaterializedViewDefinition {
-    @Schema(title = "Date when this materialized view was last modified")
+    @Schema(title = "Date when this materialized view was last refreshed")
     @PluginProperty(group = "advanced")
     private final Instant lastRefreshDate;
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/models/PolicyTags.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/models/PolicyTags.java
@@ -17,7 +17,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 @Jacksonized
 public class PolicyTags {
     @Schema(
-        name = "The policy tags' names."
+        title = "The policy tags' names."
     )
     @PluginProperty(group = "advanced")
     private final Property<List<String>> names;

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/models/RangePartitioning.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/models/RangePartitioning.java
@@ -14,11 +14,11 @@ import io.kestra.core.models.annotations.PluginProperty;
 @Builder
 @Jacksonized
 public class RangePartitioning {
-    @Schema(name = "The range partitioning field.")
+    @Schema(title = "The range partitioning field.")
     @PluginProperty(group = "advanced")
     private final Property<String> field;
 
-    @Schema(name = "The range of range partitioning.")
+    @Schema(title = "The range of range partitioning.")
     @PluginProperty(group = "advanced")
     private final Range range;
 
@@ -48,19 +48,19 @@ public class RangePartitioning {
     @Jacksonized
     public static class Range {
         @Schema(
-            name = "The start of range partitioning."
+            title = "The start of range partitioning."
         )
         @PluginProperty(group = "advanced")
         private final Property<Long> start;
 
         @Schema(
-            name = "The end of range partitioning."
+            title = "The end of range partitioning."
         )
         @PluginProperty(group = "advanced")
         private final Property<Long> end;
 
         @Schema(
-            name = "The width of each interval."
+            title = "The width of each interval."
         )
         @PluginProperty(group = "execution")
         private final Property<Long> interval;

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/models/Schema.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/models/Schema.java
@@ -17,7 +17,7 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
 @Jacksonized
 public class Schema {
     @io.swagger.v3.oas.annotations.media.Schema(
-        name = "The fields associated with this schema."
+        title = "The fields associated with this schema."
     )
     private final List<Field> fields;
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/models/StandardTableDefinition.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/models/StandardTableDefinition.java
@@ -19,19 +19,19 @@ import io.kestra.core.models.annotations.PluginProperty;
 @Builder
 @Jacksonized
 public class StandardTableDefinition {
-    @Schema(title = "Returns information on the table's streaming buffer, if exists. Returns {@code null} if no streaming buffer exists")
+    @Schema(title = "Information on the table's streaming buffer, if it exists. Null if no streaming buffer exists")
     @PluginProperty(group = "advanced")
     private final StreamingBuffer streamingBuffer;
 
-    @Schema(title = "Returns the clustering configuration for this table. If {@code null}, the table is not clustered")
+    @Schema(title = "The clustering configuration for this table. If null, the table is not clustered")
     @PluginProperty(group = "advanced")
     private final Property<List<String>> clustering;
 
-    @Schema(title = "Returns the time partitioning configuration for this table. If {@code null}, the table is not time-partitioned")
+    @Schema(title = "The time partitioning configuration for this table. If null, the table is not time-partitioned")
     @PluginProperty(group = "advanced")
     private final TimePartitioning timePartitioning;
 
-    @Schema(title = "Returns the range partitioning configuration for this table. If {@code null}, the table is not range-partitioned")
+    @Schema(title = "The range partitioning configuration for this table. If null, the table is not range-partitioned")
     @PluginProperty(group = "advanced")
     private final RangePartitioning rangePartitioning;
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/models/TimePartitioning.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/models/TimePartitioning.java
@@ -20,7 +20,7 @@ public class TimePartitioning {
     private final Property<com.google.cloud.bigquery.TimePartitioning.Type> type;
 
     @Schema(
-        title = "The number of milliseconds for which to keep the storage for a partition. When expired, the storage for the partition is reclaimed. If null, the partition does not expire"
+        title = "The duration for which to keep the storage for a partition. When expired, the storage for the partition is reclaimed. If null, the partition does not expire"
     )
     @PluginProperty(group = "advanced")
     private final Property<Duration> expiration;
@@ -54,7 +54,7 @@ public class TimePartitioning {
             builder.setField(runContext.render(this.field).as(String.class).orElseThrow());
         }
 
-        if (this.getExpiration() != null) {
+        if (this.getRequirePartitionFilter() != null) {
             builder.setRequirePartitionFilter(runContext.render(this.getRequirePartitionFilter()).as(Boolean.class).orElseThrow());
         }
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/models/UserDefinedFunction.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/models/UserDefinedFunction.java
@@ -15,14 +15,14 @@ import io.kestra.core.models.annotations.PluginProperty;
 @Jacksonized
 public class UserDefinedFunction {
     @Schema(
-        name = "The type of user defined function."
+        title = "The type of user defined function."
     )
     private final Property<com.google.cloud.bigquery.UserDefinedFunction.Type> type;
 
     @Schema(
-        name = "Type of UserDefinedFunction",
-        description = "If `type` is UserDefinedFunction.Type.INLINE, this method returns a code blob.\n" +
-            "If `type` is UserDefinedFunction.Type.FROM_URI, the method returns a Google Cloud Storage URI (e.g. gs://bucket/path)."
+        title = "The content of the user defined function",
+        description = "If `type` is INLINE, this is a code blob. " +
+            "If `type` is FROM_URI, this is a Google Cloud Storage URI (e.g. gs://bucket/path)."
     )
     @PluginProperty(group = "advanced")
     private final Property<String> content;

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/models/ViewDefinition.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/models/ViewDefinition.java
@@ -23,7 +23,7 @@ public class ViewDefinition {
     @PluginProperty(group = "processing")
     public final Property<String> query;
 
-    @Schema(title = "User defined functions that can be used by query. Returns {@code null} if not set")
+    @Schema(title = "User defined functions that can be used by query. Null if not set")
     @PluginProperty(group = "advanced")
     private final List<UserDefinedFunction> viewUserDefinedFunctions;
 

--- a/src/main/java/io/kestra/plugin/gcp/bigtable/CreateTable.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigtable/CreateTable.java
@@ -24,8 +24,7 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @Schema(
     title = "Create a Google Cloud Bigtable table",
-    description = "Creates a table with the given column families. If the table already exists, the task fails " +
-        "unless the underlying client treats creation as idempotent for the given table ID."
+    description = "Creates a table with the given column families. If the table already exists, the task fails."
 )
 @Plugin(
     examples = {

--- a/src/main/java/io/kestra/plugin/gcp/bigtable/DeleteRows.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigtable/DeleteRows.java
@@ -28,7 +28,7 @@ import lombok.experimental.SuperBuilder;
 @Schema(
     title = "Delete rows from a Google Cloud Bigtable table", description = "Deletes rows either by an explicit list of row keys, or by a row key range "
         +
-        "(`rowKeyStart`/`rowKeyEnd`) or prefix (`rowKeyPrefix`). Exactly one mode must be configured."
+        "(`rowKeyStart`/`rowKeyEnd`) or prefix (`rowKeyPrefix`). At least one mode must be configured; if several are set, `rowKeys` takes precedence, then the prefix, then the range."
 )
 @Plugin(
     examples = {
@@ -67,7 +67,7 @@ public class DeleteRows extends AbstractBigtable implements RunnableTask<DeleteR
     @PluginProperty(group = "main")
     private Property<String> tableId;
 
-    @Schema(title = "Exact row keys to delete", description = "Mutually exclusive with `rowKeyStart`/`rowKeyEnd` and `rowKeyPrefix`.")
+    @Schema(title = "Exact row keys to delete", description = "Takes precedence over `rowKeyStart`/`rowKeyEnd` and `rowKeyPrefix` if several are set.")
     @PluginProperty(group = "source")
     private Property<List<String>> rowKeys;
 
@@ -79,7 +79,7 @@ public class DeleteRows extends AbstractBigtable implements RunnableTask<DeleteR
     @PluginProperty(group = "source")
     private Property<String> rowKeyEnd;
 
-    @Schema(title = "Row key prefix to match rows for deletion", description = "Mutually exclusive with `rowKeyStart`/`rowKeyEnd` and `rowKeys`.")
+    @Schema(title = "Row key prefix to match rows for deletion", description = "Used when `rowKeys` is not set; takes precedence over `rowKeyStart`/`rowKeyEnd` if both are set.")
     @PluginProperty(group = "source")
     private Property<String> rowKeyPrefix;
 

--- a/src/main/java/io/kestra/plugin/gcp/bigtable/ReadRows.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigtable/ReadRows.java
@@ -59,7 +59,7 @@ import lombok.experimental.SuperBuilder;
                 """
         ),
         @Example(
-            title = "Read a single row by exact row key",
+            title = "Read the first row within a row key range",
             full = true,
             code = """
                 id: bigtable_read_one_row

--- a/src/main/java/io/kestra/plugin/gcp/dataform/InvokeWorkflow.java
+++ b/src/main/java/io/kestra/plugin/gcp/dataform/InvokeWorkflow.java
@@ -66,7 +66,7 @@ public class InvokeWorkflow extends AbstractDataForm implements RunnableTask<Inv
         description = "If true (default), polls the invocation until it leaves RUNNING"
     )
     @PluginProperty(group = "execution")
-    protected Boolean wait = true;;
+    protected Boolean wait = true;
 
     @Override
     public Output run(RunContext runContext) throws Exception {

--- a/src/main/java/io/kestra/plugin/gcp/dataproc/batches/AbstractBatch.java
+++ b/src/main/java/io/kestra/plugin/gcp/dataproc/batches/AbstractBatch.java
@@ -170,8 +170,6 @@ public abstract class AbstractBatch extends AbstractTask implements RunnableTask
                 batchBuilder.setRuntimeConfig(runtimeConfig.build());
             }
 
-            batchBuilder.setEnvironmentConfig(EnvironmentConfig.newBuilder().build());
-
             Batch batch = batchBuilder.build();
 
             logger.info("Starting with batch id '{}'", batchId);

--- a/src/main/java/io/kestra/plugin/gcp/dataproc/batches/SparkSqlSubmit.java
+++ b/src/main/java/io/kestra/plugin/gcp/dataproc/batches/SparkSqlSubmit.java
@@ -36,7 +36,7 @@ import io.kestra.core.models.annotations.PluginProperty;
             tasks:
               - id: spark_sql_submit
                 type: io.kestra.plugin.gcp.dataproc.batches.SparkSqlSubmit
-                queryFileUri: 'gs://spark-jobs-kestra/foobar.py'
+                queryFileUri: 'gs://spark-jobs-kestra/foobar.sql'
                 name: test-sparksql
                 region: europe-west3
             """

--- a/src/main/java/io/kestra/plugin/gcp/dataproc/clusters/Create.java
+++ b/src/main/java/io/kestra/plugin/gcp/dataproc/clusters/Create.java
@@ -66,7 +66,7 @@ import lombok.experimental.SuperBuilder;
                     workerMachineType: n1-standard-2
                     workerDiskSizeGB: 200
                     workers: 2
-                    bucket: YOUR_BUCKET_NAM
+                    bucket: YOUR_BUCKET_NAME
                 """
         )
     }

--- a/src/main/java/io/kestra/plugin/gcp/dataproc/clusters/Delete.java
+++ b/src/main/java/io/kestra/plugin/gcp/dataproc/clusters/Delete.java
@@ -39,8 +39,8 @@ import lombok.experimental.SuperBuilder;
             namespace: company.team
 
             tasks:
-              - id: create_cluster_with_certain_disk_size
-                type: io.kestra.plugin.gcp.dataproc.clusters.Create
+              - id: cluster_delete
+                type: io.kestra.plugin.gcp.dataproc.clusters.Delete
                 clusterName: YOUR_CLUSTER_NAME
                 region: YOUR_REGION
             """

--- a/src/main/java/io/kestra/plugin/gcp/firestore/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/firestore/Query.java
@@ -122,18 +122,18 @@ public class Query extends AbstractFirestore implements RunnableTask<FetchOutput
             var query = getQuery(runContext, collectionRef, this.filters);
 
             if (this.orderBy != null) {
-                query.orderBy(
+                query = query.orderBy(
                     runContext.render(this.orderBy).as(String.class).orElseThrow(),
                     runContext.render(this.orderDirection).as(Direction.class).orElseThrow()
                 );
             }
 
             if (this.offset != null) {
-                query.offset(runContext.render(this.offset).as(Integer.class).orElseThrow());
+                query = query.offset(runContext.render(this.offset).as(Integer.class).orElseThrow());
             }
 
             if (this.limit != null) {
-                query.limit(runContext.render(this.limit).as(Integer.class).orElseThrow());
+                query = query.limit(runContext.render(this.limit).as(Integer.class).orElseThrow());
             }
 
             var queryDocumentSnapshots = query.get().get().getDocuments();

--- a/src/main/java/io/kestra/plugin/gcp/firestore/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/firestore/Query.java
@@ -122,18 +122,18 @@ public class Query extends AbstractFirestore implements RunnableTask<FetchOutput
             var query = getQuery(runContext, collectionRef, this.filters);
 
             if (this.orderBy != null) {
-                query = query.orderBy(
+                query.orderBy(
                     runContext.render(this.orderBy).as(String.class).orElseThrow(),
                     runContext.render(this.orderDirection).as(Direction.class).orElseThrow()
                 );
             }
 
             if (this.offset != null) {
-                query = query.offset(runContext.render(this.offset).as(Integer.class).orElseThrow());
+                query.offset(runContext.render(this.offset).as(Integer.class).orElseThrow());
             }
 
             if (this.limit != null) {
-                query = query.limit(runContext.render(this.limit).as(Integer.class).orElseThrow());
+                query.limit(runContext.render(this.limit).as(Integer.class).orElseThrow());
             }
 
             var queryDocumentSnapshots = query.get().get().getDocuments();

--- a/src/main/java/io/kestra/plugin/gcp/gcs/Copy.java
+++ b/src/main/java/io/kestra/plugin/gcp/gcs/Copy.java
@@ -39,14 +39,11 @@ import io.kestra.core.models.annotations.PluginProperty;
                 id: gcp_gcs_copy
                 namespace: company.team
 
-                inputs:
-                  - id: file
-                    type: FILE
-
                 tasks:
                   - id: copy
                     type: io.kestra.plugin.gcp.gcs.Copy
-                    from: "{{ inputs.file }}"
+                    from: "gs://my_bucket/dir/file.csv"
+                    to: "gs://my_bucket/archive/file.csv"
                     delete: true
                 """
         )

--- a/src/main/java/io/kestra/plugin/gcp/gcs/Trigger.java
+++ b/src/main/java/io/kestra/plugin/gcp/gcs/Trigger.java
@@ -76,7 +76,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 
                 tasks:
                   - id: each
-                    type: io.kestra.plugin.core.flow.EachSequential
+                    type: io.kestra.plugin.core.flow.ForEach
                     values: "{{ trigger.blobs | jq('.[].uri') }}"
                     tasks:
                       - id: return

--- a/src/main/java/io/kestra/plugin/gcp/gcs/Upload.java
+++ b/src/main/java/io/kestra/plugin/gcp/gcs/Upload.java
@@ -39,7 +39,7 @@ import lombok.experimental.SuperBuilder;
     examples = {
         @Example(
             full = true,
-            title = "Uploada FILE input to GCS",
+            title = "Upload a FILE input to GCS",
             code = """
                 id: gcp_gcs_upload
                 namespace: company.team

--- a/src/main/java/io/kestra/plugin/gcp/pubsub/Publish.java
+++ b/src/main/java/io/kestra/plugin/gcp/pubsub/Publish.java
@@ -28,7 +28,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 @NoArgsConstructor
 @Schema(
     title = "Publish messages to Pub/Sub",
-    description = "Publishes one or more messages to a topic. Supports STRING/JSON/AVRO serde and optional ordering keys."
+    description = "Publishes one or more messages to a topic. Supports STRING/JSON serde and optional ordering keys."
 )
 @Plugin(
     examples = {

--- a/src/main/java/io/kestra/plugin/gcp/rcs/SendFile.java
+++ b/src/main/java/io/kestra/plugin/gcp/rcs/SendFile.java
@@ -59,7 +59,7 @@ public class SendFile extends AbstractRcs implements RunnableTask<SendFile.Outpu
     @PluginProperty(group = "main", internalStorageURI = true)
     private Property<String> file;
 
-    @Schema(title = "Optional thumbnail image URI (can be a public HTTPS URL or a Kestra internal storage URI)")
+    @Schema(title = "Optional thumbnail image URI. Only applied when `file` is a public HTTPS URL; ignored when `file` is a Kestra internal storage URI.")
     @PluginProperty(group = "main", internalStorageURI = true)
     private Property<String> thumbnail;
 

--- a/src/main/java/io/kestra/plugin/gcp/rcs/SendFile.java
+++ b/src/main/java/io/kestra/plugin/gcp/rcs/SendFile.java
@@ -59,7 +59,7 @@ public class SendFile extends AbstractRcs implements RunnableTask<SendFile.Outpu
     @PluginProperty(group = "main", internalStorageURI = true)
     private Property<String> file;
 
-    @Schema(title = "Optional thumbnail image URI. Only applied when `file` is a public HTTPS URL; ignored when `file` is a Kestra internal storage URI.")
+    @Schema(title = "Optional thumbnail image URI. Only applied when `file` is a public HTTPS URL; ignored when `file` is a Kestra internal storage URI")
     @PluginProperty(group = "main", internalStorageURI = true)
     private Property<String> thumbnail;
 

--- a/src/main/java/io/kestra/plugin/gcp/services/LogTailService.java
+++ b/src/main/java/io/kestra/plugin/gcp/services/LogTailService.java
@@ -57,8 +57,10 @@ public class LogTailService {
         switch (logEntry.getSeverity()) {
             case DEBUG:
                 logger.debug("{}", logEntry.toStructuredJsonString());
+                break;
             case WARNING:
                 logger.warn("{}", logEntry.toStructuredJsonString());
+                break;
             case ERROR:
             case CRITICAL:
             case ALERT:

--- a/src/main/java/io/kestra/plugin/gcp/spanner/DeleteDatabase.java
+++ b/src/main/java/io/kestra/plugin/gcp/spanner/DeleteDatabase.java
@@ -17,7 +17,7 @@ import lombok.experimental.SuperBuilder;
 @NoArgsConstructor
 @Schema(
     title = "Delete a Spanner database",
-    description = "Permanently deletes a Spanner database and all of its schema and cells."
+    description = "Permanently deletes a Spanner database and all of its schema and data."
 )
 @Plugin(
     examples = {

--- a/src/main/java/io/kestra/plugin/gcp/spanner/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/spanner/Query.java
@@ -45,9 +45,9 @@ import lombok.experimental.SuperBuilder;
                 namespace: company.team
 
                 inputs:
-                  - id: min_age
-                    type: INT
-                    defaults: 18
+                  - id: department
+                    type: STRING
+                    defaults: engineering
 
                 tasks:
                   - id: query
@@ -55,9 +55,9 @@ import lombok.experimental.SuperBuilder;
                     projectId: "{{ secret('GCP_PROJECT_ID') }}"
                     instanceId: my-instance
                     databaseId: my-database
-                    sql: "SELECT * FROM users WHERE age >= @minAge"
+                    sql: "SELECT * FROM users WHERE department = @department"
                     parameters:
-                      minAge: "{{ inputs.min_age }}"
+                      department: "{{ inputs.department }}"
                     fetchType: STORE
                 """
         )

--- a/src/main/java/io/kestra/plugin/gcp/vertexai/AbstractGenerativeAi.java
+++ b/src/main/java/io/kestra/plugin/gcp/vertexai/AbstractGenerativeAi.java
@@ -92,7 +92,7 @@ abstract class AbstractGenerativeAi extends AbstractTask {
         @Max(1)
         @Schema(
             title = "Temperature used for sampling during the response generation, which occurs when topP and topK are applied",
-            description = "Temperature controls the degree of randomness in token selection. Lower temperatures are good for prompts that require a more deterministic and less open-ended or creative response, while higher temperatures can lead to more diverse or creative results. A temperature of 0 is deterministic: the highest probability response is always selected. For most use cases, try starting with a temperature of 0.2."
+            description = "Temperature controls the degree of randomness in token selection. Lower temperatures are good for prompts that require a more deterministic and less open-ended or creative response, while higher temperatures can lead to more diverse or creative results. A temperature close to 0 is nearly deterministic: the highest probability response is almost always selected. For most use cases, try starting with a temperature of 0.2."
         )
         private Float temperature = 0.2F;
 

--- a/src/main/java/io/kestra/plugin/gcp/vertexai/ChatCompletion.java
+++ b/src/main/java/io/kestra/plugin/gcp/vertexai/ChatCompletion.java
@@ -51,10 +51,8 @@ import static io.kestra.core.utils.Rethrow.throwFunction;
                     type: io.kestra.plugin.gcp.vertexai.ChatCompletion
                     region: us-central1
                     projectId: my-project
-                    context: I love jokes that talk about sport
                     messages:
-                      - author: user
-                        content: Please tell me a joke
+                      - content: Please tell me a joke that talks about sport
                 """
         )
     },

--- a/src/main/java/io/kestra/plugin/gcp/vertexai/CustomJob.java
+++ b/src/main/java/io/kestra/plugin/gcp/vertexai/CustomJob.java
@@ -267,9 +267,9 @@ public class CustomJob extends AbstractTask implements RunnableTask<CustomJob.Ou
         )
         private final Instant updateDate;
 
-        @NotNull
         @Schema(
-            title = "Time when the CustomJob was ended"
+            title = "Time when the CustomJob was ended",
+            description = "Only populated when `wait` is true."
         )
         private final Instant endDate;
 

--- a/src/main/java/io/kestra/plugin/gcp/vertexai/models/MachineSpec.java
+++ b/src/main/java/io/kestra/plugin/gcp/vertexai/models/MachineSpec.java
@@ -16,7 +16,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 @Jacksonized
 public class MachineSpec {
     @Schema(
-        title = " The type of the machine",
+        title = "The type of the machine",
         description = "See the [list of machine types supported for" +
             "prediction](https://cloud.google.com/vertex-ai/docs/predictions/configure-compute#machine-types)\n" +
             "See the [list of machine types supported for custom " +

--- a/src/main/java/io/kestra/plugin/gcp/vertexai/models/PythonPackageSpec.java
+++ b/src/main/java/io/kestra/plugin/gcp/vertexai/models/PythonPackageSpec.java
@@ -32,8 +32,8 @@ public class PythonPackageSpec {
     private Property<List<String>> packageUris;
 
     @Schema(
-        title = "The Google Cloud Storage location of the Python package files which are the training program and its dependent packages",
-        description = "The maximum number of package URIs is 100."
+        title = "Command line arguments passed to the Python task",
+        description = "The arguments to pass to the Python module being run."
     )
     @NotNull
     @PluginProperty(group = "main")
@@ -60,9 +60,10 @@ public class PythonPackageSpec {
             builder.addAllArgs(renderedArgs);
         }
 
-        if (!renderedPackage.isEmpty()) {
+        var renderedEnvs = runContext.render(this.envs).asMap(String.class, String.class);
+        if (!renderedEnvs.isEmpty()) {
             builder.addAllEnv(
-                runContext.render(this.envs).asMap(String.class, String.class)
+                renderedEnvs
                     .entrySet()
                     .stream()
                     .map(

--- a/src/main/java/io/kestra/plugin/gcp/vertexai/models/Scheduling.java
+++ b/src/main/java/io/kestra/plugin/gcp/vertexai/models/Scheduling.java
@@ -18,7 +18,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 @Jacksonized
 public class Scheduling {
     @Schema(
-        title = "The maximum job running time. The default is 7 days"
+        title = "The maximum job running time"
     )
     @NotNull
     @PluginProperty(group = "main")

--- a/src/main/java/io/kestra/plugin/gcp/vertexai/models/WorkerPoolSpec.java
+++ b/src/main/java/io/kestra/plugin/gcp/vertexai/models/WorkerPoolSpec.java
@@ -16,7 +16,7 @@ import lombok.extern.jackson.Jacksonized;
 @Jacksonized
 public class WorkerPoolSpec {
     @Schema(
-        title = " The custom container task"
+        title = "The custom container task"
     )
     @PluginProperty(dynamic = false, group = "main")
     @NotNull
@@ -36,7 +36,7 @@ public class WorkerPoolSpec {
     private DiscSpec discSpec;
 
     @Schema(
-        title = "The specification of the disk"
+        title = "The number of worker replicas to use for this pool"
     )
     @PluginProperty(group = "advanced")
     private Property<Integer> replicaCount;


### PR DESCRIPTION
## What

Plugin-wide correctness pass over documentation, `@Schema` annotations, `@Example` YAML, `@Metric` declarations, and `@Output` fields — verified against actual code behavior. Along the way this fixes seven genuine code bugs where the runtime did not do what the documentation promised.

Covers `bigquery`, `pubsub`, `firestore`, `monitoring`, `bigtable`, `spanner`, `dataflow`, `dataproc`, `dataform`, `gke`, `vertexai`, `gcs`, `rcs`, `auth`, and shared services.

## Why

Generated plugin docs are driven directly off these annotations and examples. Stale copy-paste descriptions, leaked Javadoc tokens, misused annotation attributes, and examples that reference non-existent properties or would fail at runtime all surface to users as incorrect documentation. Several `@Schema`/`@Output` fields also documented behavior the code never actually performed.

## Changes

### Code bugs (behavior-changing)

These are cases where the documented (and intended) behavior was not what the code did:

- **`bigquery/CopyPartitions`** — `Output.of(...)` never set `.jobId(...)`, so the documented `jobId` output was always `null`.
- **`bigquery/TimePartitioning`** — `requirePartitionFilter` was gated on `expiration != null` (copy-pasted guard), so setting it alone was a no-op.
- **`firestore/Query`** — `orderBy`/`offset`/`limit` return values were discarded (the Firestore query is immutable), making documented ordering and pagination silent no-ops.
- **`dataproc/AbstractBatch`** — the environment config built from `execution`/`peripherals` was reset to empty immediately before `build()`, discarding both documented settings.
- **`vertexai/PythonPackageSpec`** — env vars were gated on `packageUris` being non-empty, so they were dropped whenever packages were empty.
- **`services/LogTailService`** — missing `break;` statements caused DEBUG/WARNING entries to fall through and log at ERROR level.
- **`dataform/InvokeWorkflow`** — stray double semicolon.

### Documentation & annotation fixes

- **Wrong/contradictory descriptions** corrected across `bigquery` (`useLegacySql`, `UserDefinedFunction.content`, `Field.subFields`, `TimePartitioning.expiration`, `MaterializedViewDefinition`, `AbstractTableCreateUpdate`, `StorageWrite`, `retryAuto`), `pubsub/Publish` (removed non-existent AVRO serde), `auth/OauthAccessToken` ("current user" → service account), `vertexai` (`PythonPackageSpec.args`, `WorkerPoolSpec.replicaCount`, `Scheduling.timeOut`, `temperature` vs `@Positive`, `CustomJob.endDate`), `spanner/DeleteDatabase` ("cells" → "data"), `bigtable/CreateTable` (removed false idempotency hedge), `bigtable/DeleteRows` (documented actual precedence: rowKeys > prefix > range), and `rcs/SendFile` (thumbnail only applies to HTTPS-URL files).
- **Doc-rendering fixes** — converted misused `@Schema(name = "<sentence>")` to `title =` in five `bigquery/models` classes; removed leaked Javadoc tokens (`{@code}`, `{@link #setXxx}`, stray `* ` markers) from `AbstractLoad`, `StandardTableDefinition`, `ViewDefinition`, `ExternalTableDefinition`; stripped leading-space titles in `vertexai` models.
- **`@Metric`** — declared the emitted-but-undeclared `total.rows` and `fetch.rows` on `bigquery/Query`; fixed a "totla" typo.

### Example (YAML) fixes

- **`bigquery/LoadFromGcs`** — added a `gcs.Upload` step so `from` references a real `gs://` URI (load-from-GCS rejects Kestra internal URIs).
- **`gcs/Copy`** — replaced the FILE-input example with valid `gs://` `from`/`to` (copy is bucket-to-bucket and `to` is required).
- **`spanner/Query`** — switched the INT-parameter example to a STRING column (templated map values render to strings and mismatched the INT64 bind).
- **`dataproc/clusters/Delete`** — example showed a `Create` task; now shows `Delete`.
- **`bigquery/Query` + `Trigger`, `gcs/Trigger`, `vertexai/ChatCompletion`** — replaced deprecated properties/tasks in examples (`fetch` → `fetchType`, `EachSequential` → `ForEach`, dropped deprecated `context`/`author`).
- Miscellaneous title/typo fixes (`bigtable/ReadRows`, `gcs/Upload`, `dataproc/Create` bucket placeholder, `SparkSqlSubmit` `.py` → `.sql`, `CreateDataset`, `Load`).

## Not included (reported for follow-up)

- `rcs/AbstractRcs` overrides the inherited `scopes` property to a fixed value, so user-set `scopes` is ignored — resolving this is a design choice.
- `vertexai/DiscSpec` / `discSpec` is misspelled vs GCP's `DiskSpec`; renaming the user-facing YAML property would be a breaking change.

## Test plan

- [x] `./gradlew compileJava` passes (exit 0).
- [x] All fixes independently re-verified against current code by adversarial review; the one defect found during verification (a swapped precedence description in `DeleteRows`) was corrected.
- [ ] Run the test suite: `./gradlew test`.