### PR TITLE
fix(bigquery): keep the cause of errorless BigQuery failures

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
@@ -38,6 +38,9 @@ import lombok.experimental.SuperBuilder;
 abstract public class AbstractBigquery extends AbstractTask implements WorkerJobLifecycle {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractBigquery.class);
 
+    /** Guards the cause-chain walk against a cyclic chain. Real chains are an order of magnitude shorter. */
+    private static final int MAX_CAUSE_DEPTH = 20;
+
     @Schema(
         title = "Dataset location",
         description = "Optional BigQuery location for created or targeted resources. Experimental and may change; see BigQuery dataset location documentation."
@@ -251,48 +254,41 @@ abstract public class AbstractBigquery extends AbstractTask implements WorkerJob
 
                     return job;
                 } catch (Exception exception) {
-                    JobId jobId = job != null ? job.getJobId() : lastJobId.get();
+                    var jobId = job != null ? job.getJobId() : lastJobId.get();
 
                     if (isInterrupted(exception)) {
-                        throw this.interrupted(logger, jobId, exception);
+                        throw this.interruptedFailure(logger, jobId, exception);
                     }
 
+                    List<BigQueryError> errors = null;
                     if (exception instanceof com.google.cloud.bigquery.BigQueryException bqException) {
-                        List<BigQueryError> errors = BigQueryService.errorsOf(bqException);
-
-                        logger.warn(
-                            "Error query on {} with errors:\n[\n - {}\n]",
-                            jobId != null ? "job '" + jobId.getJob() + "'" : "create job",
-                            String.join("\n - ", errors.stream().map(BigQueryError::toString).toArray(String[]::new))
-                        );
-
-                        throw new BigQueryException(errors, bqException);
-                    } else if (exception instanceof JobException bqException) {
-                        List<BigQueryError> errors = BigQueryService.errorsOf(bqException);
-
-                        logger.warn(
-                            "Error query on {} with errors:\n[\n - {}\n]",
-                            jobId != null ? "job '" + jobId.getJob() + "'" : "create job",
-                            String.join("\n - ", errors.stream().map(BigQueryError::toString).toArray(String[]::new))
-                        );
-
-                        throw new BigQueryException(errors, bqException);
+                        // Inferring a retryable reason from a bare status is only safe once the job id is
+                        // known, because the lookback above then re-attaches instead of resubmitting. A
+                        // failed submission cannot tell an accepted job from a lost one, and BigQuery
+                        // assigns the id itself (#674), so retrying there would run the statement twice.
+                        errors = BigQueryService.errorsOf(bqException, jobId != null);
+                    } else if (exception instanceof JobException jobException) {
+                        errors = BigQueryService.errorsOf(jobException);
                     }
 
-                    throw exception;
+                    if (errors == null) {
+                        throw exception;
+                    }
+
+                    logger.warn(
+                        "Error query on {} with errors:\n[\n - {}\n]",
+                        jobId != null ? "job '" + jobId.getJob() + "'" : "create job",
+                        String.join("\n - ", errors.stream().map(BigQueryError::toString).toArray(String[]::new))
+                    );
+
+                    throw new BigQueryException(errors, exception);
                 }
             });
     }
 
-    /**
-     * The worker interrupts the task thread on a kill, on a task timeout, and on {@code shutdownNow()}
-     * when a worker terminates. The BigQuery client surfaces that as a BigQueryException wrapping an
-     * InterruptedException, with no error list and no HTTP code, so it has to be recognised before the
-     * generic handling below turns it into an errorless failure.
-     */
+    /** The client wraps an interrupt in a BigQueryException carrying no error list, so match on the cause chain. */
     private static boolean isInterrupted(Throwable throwable) {
-        // Bounded walk: a malformed cause chain must not spin here.
-        for (int depth = 0; throwable != null && depth < 20; throwable = throwable.getCause(), depth++) {
+        for (int depth = 0; throwable != null && depth < MAX_CAUSE_DEPTH; throwable = throwable.getCause(), depth++) {
             if (throwable instanceof InterruptedException) {
                 return true;
             }
@@ -302,15 +298,13 @@ abstract public class AbstractBigquery extends AbstractTask implements WorkerJob
     }
 
     /**
-     * Reports an interrupted wait against the job it was waiting on. Retrying is pointless once the
-     * thread carries the interrupt flag, so this is deliberately not a retryable reason, but the job id
-     * has to reach the user: unless the task was killed, the job keeps running on BigQuery and will
-     * complete there while Kestra reports the task as failed.
+     * Deliberately not a retryable reason: an interrupted thread cannot make progress. Names the job,
+     * which outlives the task unless the kill already cancelled it.
      */
-    private BigQueryException interrupted(Logger logger, JobId jobId, Throwable cause) {
+    private BigQueryException interruptedFailure(Logger logger, JobId jobId, Throwable cause) {
         Thread.currentThread().interrupt();
 
-        String message = "Interrupted while waiting for BigQuery job"
+        var message = "Interrupted while waiting for BigQuery job"
             + (jobId != null ? " '" + jobId.getJob() + "'" : "")
             + (this.isCancelled.get()
                 ? ", the job was cancelled."
@@ -322,6 +316,11 @@ abstract public class AbstractBigquery extends AbstractTask implements WorkerJob
     }
 
     boolean shouldRetry(Throwable failure, Logger logger, RunContext runContext) throws IllegalVariableEvaluationException {
+        // Structural, not a matter of which reasons are configured: an interrupted thread cannot back off.
+        if (Thread.currentThread().isInterrupted()) {
+            return false;
+        }
+
         if (!(failure instanceof BigQueryException)) {
             logger.warn("Cancelled retrying, unknown exception type {}", failure.getClass(), failure);
             return false;

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
@@ -261,12 +261,16 @@ abstract public class AbstractBigquery extends AbstractTask implements WorkerJob
                     }
 
                     List<BigQueryError> errors = null;
+                    var retryable = false;
+
                     if (exception instanceof com.google.cloud.bigquery.BigQueryException bqException) {
-                        // Inferring a retryable reason from a bare status is only safe once the job id is
-                        // known, because the lookback above then re-attaches instead of resubmitting. A
-                        // failed submission cannot tell an accepted job from a lost one, and BigQuery
-                        // assigns the id itself (#674), so retrying there would run the statement twice.
-                        errors = BigQueryService.errorsOf(bqException, jobId != null);
+                        errors = BigQueryService.errorsOf(bqException);
+
+                        // Trust the client's verdict only once the job id is known, because the lookback
+                        // above can then re-attach instead of resubmitting. A failed submission cannot
+                        // tell an accepted job from a lost one, and BigQuery assigns the id itself
+                        // (#674), so retrying there would run the statement twice.
+                        retryable = jobId != null && bqException.isRetryable();
                     } else if (exception instanceof JobException jobException) {
                         errors = BigQueryService.errorsOf(jobException);
                     }
@@ -281,7 +285,7 @@ abstract public class AbstractBigquery extends AbstractTask implements WorkerJob
                         String.join("\n - ", errors.stream().map(BigQueryError::toString).toArray(String[]::new))
                     );
 
-                    throw new BigQueryException(errors, exception);
+                    throw new BigQueryException(errors, exception, retryable);
                 }
             });
     }
@@ -312,7 +316,7 @@ abstract public class AbstractBigquery extends AbstractTask implements WorkerJob
 
         logger.warn(message, cause);
 
-        return new BigQueryException(List.of(new BigQueryError("interrupted", null, message)), cause);
+        return new BigQueryException(List.of(new BigQueryError("interrupted", null, message)), cause, false);
     }
 
     boolean shouldRetry(Throwable failure, Logger logger, RunContext runContext) throws IllegalVariableEvaluationException {
@@ -321,12 +325,17 @@ abstract public class AbstractBigquery extends AbstractTask implements WorkerJob
             return false;
         }
 
-        if (!(failure instanceof BigQueryException)) {
+        if (!(failure instanceof BigQueryException bigQueryException)) {
             logger.warn("Cancelled retrying, unknown exception type {}", failure.getClass(), failure);
             return false;
         }
 
-        for (BigQueryError error : ((BigQueryException) failure).getErrors()) {
+        // A transport failure carries no BigQuery reason to match on, so defer to the client.
+        if (bigQueryException.isRetryable()) {
+            return true;
+        }
+
+        for (BigQueryError error : bigQueryException.getErrors()) {
             if (error.getReason() != null && runContext.render(this.retryReasons).asList(String.class).contains(error.getReason())) {
                 return true;
             }

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
@@ -8,12 +8,11 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.bigquery.*;
 
@@ -252,29 +251,74 @@ abstract public class AbstractBigquery extends AbstractTask implements WorkerJob
 
                     return job;
                 } catch (Exception exception) {
+                    JobId jobId = job != null ? job.getJobId() : lastJobId.get();
+
+                    if (isInterrupted(exception)) {
+                        throw this.interrupted(logger, jobId, exception);
+                    }
+
                     if (exception instanceof com.google.cloud.bigquery.BigQueryException bqException) {
+                        List<BigQueryError> errors = BigQueryService.errorsOf(bqException);
 
                         logger.warn(
                             "Error query on {} with errors:\n[\n - {}\n]",
-                            job != null ? "job '" + job.getJobId().getJob() + "'" : "create job",
-                            bqException.getErrors() == null ? "" : String.join("\n - ", bqException.getErrors().stream().map(BigQueryError::toString).toArray(String[]::new))
+                            jobId != null ? "job '" + jobId.getJob() + "'" : "create job",
+                            String.join("\n - ", errors.stream().map(BigQueryError::toString).toArray(String[]::new))
                         );
 
-                        throw new BigQueryException(bqException.getErrors());
+                        throw new BigQueryException(errors, bqException);
                     } else if (exception instanceof JobException bqException) {
+                        List<BigQueryError> errors = BigQueryService.errorsOf(bqException);
 
                         logger.warn(
-                            "Error query on job '{}' with errors:\n[\n - {}\n]",
-                            job != null ? "job '" + job.getJobId().getJob() + "'" : "create job",
-                            bqException.getErrors() == null ? "" : String.join("\n - ", bqException.getErrors().stream().map(BigQueryError::toString).toArray(String[]::new))
+                            "Error query on {} with errors:\n[\n - {}\n]",
+                            jobId != null ? "job '" + jobId.getJob() + "'" : "create job",
+                            String.join("\n - ", errors.stream().map(BigQueryError::toString).toArray(String[]::new))
                         );
 
-                        throw new BigQueryException(bqException.getErrors());
+                        throw new BigQueryException(errors, bqException);
                     }
 
                     throw exception;
                 }
             });
+    }
+
+    /**
+     * The worker interrupts the task thread on a kill, on a task timeout, and on {@code shutdownNow()}
+     * when a worker terminates. The BigQuery client surfaces that as a BigQueryException wrapping an
+     * InterruptedException, with no error list and no HTTP code, so it has to be recognised before the
+     * generic handling below turns it into an errorless failure.
+     */
+    private static boolean isInterrupted(Throwable throwable) {
+        // Bounded walk: a malformed cause chain must not spin here.
+        for (int depth = 0; throwable != null && depth < 20; throwable = throwable.getCause(), depth++) {
+            if (throwable instanceof InterruptedException) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Reports an interrupted wait against the job it was waiting on. Retrying is pointless once the
+     * thread carries the interrupt flag, so this is deliberately not a retryable reason, but the job id
+     * has to reach the user: unless the task was killed, the job keeps running on BigQuery and will
+     * complete there while Kestra reports the task as failed.
+     */
+    private BigQueryException interrupted(Logger logger, JobId jobId, Throwable cause) {
+        Thread.currentThread().interrupt();
+
+        String message = "Interrupted while waiting for BigQuery job"
+            + (jobId != null ? " '" + jobId.getJob() + "'" : "")
+            + (this.isCancelled.get()
+                ? ", the job was cancelled."
+                : ". The job was not cancelled and may still be running on BigQuery.");
+
+        logger.warn(message, cause);
+
+        return new BigQueryException(List.of(new BigQueryError("interrupted", null, message)), cause);
     }
 
     boolean shouldRetry(Throwable failure, Logger logger, RunContext runContext) throws IllegalVariableEvaluationException {
@@ -284,11 +328,11 @@ abstract public class AbstractBigquery extends AbstractTask implements WorkerJob
         }
 
         for (BigQueryError error : ((BigQueryException) failure).getErrors()) {
-            if (runContext.render(this.retryReasons).asList(String.class).contains(error.getReason())) {
+            if (error.getReason() != null && runContext.render(this.retryReasons).asList(String.class).contains(error.getReason())) {
                 return true;
             }
 
-            if (this.retryMessages != null) {
+            if (this.retryMessages != null && error.getMessage() != null) {
                 for (String message : runContext.render(this.retryMessages).asList(String.class)) {
                     if (error.getMessage().toLowerCase().contains(message.toLowerCase())) {
                         return true;

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryException.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryException.java
@@ -12,14 +12,21 @@ import lombok.Getter;
 public class BigQueryException extends Exception {
     private final List<BigQueryError> errors;
 
+    /**
+     * The client's own verdict on the underlying failure, and only where a retry can be deduplicated.
+     * A transport failure carries no BigQuery error reason, so retryReasons cannot speak for it.
+     */
+    private final boolean retryable;
+
     BigQueryException(List<BigQueryError> errors) {
-        this(errors, null);
+        this(errors, null, false);
     }
 
     /** Keeps the originating exception as the cause: a transport failure has nothing in its error list. */
-    BigQueryException(List<BigQueryError> errors, Throwable cause) {
+    BigQueryException(List<BigQueryError> errors, Throwable cause, boolean retryable) {
         super(formatErrors(Objects.requireNonNullElse(errors, List.of())), cause);
         this.errors = Objects.requireNonNullElse(errors, List.of());
+        this.retryable = retryable;
     }
 
     private static String formatErrors(List<BigQueryError> errors) {

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryException.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryException.java
@@ -13,7 +13,16 @@ public class BigQueryException extends Exception {
     private final List<BigQueryError> errors;
 
     BigQueryException(List<BigQueryError> errors) {
-        super(formatErrors(Objects.requireNonNullElse(errors, List.of())));
+        this(errors, null);
+    }
+
+    /**
+     * Keeps the originating exception as the cause. BigQuery only fills the error list for job-level
+     * failures, so transport failures used to be rethrown with an empty list and no cause, which left
+     * the user with a "Bigquery Errors [ - ]" message and nothing to diagnose.
+     */
+    BigQueryException(List<BigQueryError> errors, Throwable cause) {
+        super(formatErrors(Objects.requireNonNullElse(errors, List.of())), cause);
         this.errors = Objects.requireNonNullElse(errors, List.of());
     }
 
@@ -21,7 +30,8 @@ public class BigQueryException extends Exception {
         return "Bigquery Errors\n[ - " +
             errors.stream()
                 .map(BigQueryError::toString)
-                .collect(Collectors.joining("\n - ")) +
+                .collect(Collectors.joining("\n - "))
+            +
             "\n]";
     }
 }

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryException.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryException.java
@@ -16,11 +16,7 @@ public class BigQueryException extends Exception {
         this(errors, null);
     }
 
-    /**
-     * Keeps the originating exception as the cause. BigQuery only fills the error list for job-level
-     * failures, so transport failures used to be rethrown with an empty list and no cause, which left
-     * the user with a "Bigquery Errors [ - ]" message and nothing to diagnose.
-     */
+    /** Keeps the originating exception as the cause: a transport failure has nothing in its error list. */
     BigQueryException(List<BigQueryError> errors, Throwable cause) {
         super(formatErrors(Objects.requireNonNullElse(errors, List.of())), cause);
         this.errors = Objects.requireNonNullElse(errors, List.of());

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryService.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryService.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.slf4j.Logger;
 
@@ -64,24 +65,17 @@ public class BigQueryService {
 
     /**
      * BigQuery fills the error list only for job-level failures. A transport failure (bare 5xx, socket
-     * error, interrupted poll) arrives with it null, so fold the exception's own reason and message into
-     * one error: otherwise the failure reads as "Bigquery Errors [ - ]" and retryReasons has no match.
-     *
-     * @param inferRetryableReason derive a reason from the HTTP status when BigQuery returned none.
-     *        Only pass true where a retry can be deduplicated.
+     * error, interrupted poll) arrives with it null, so carry the exception's own reason and message as
+     * a single error: otherwise the failure reads as "Bigquery Errors [ - ]" with nothing to diagnose.
+     * Whether such a failure is worth retrying is the client's call, not a reason string's.
      */
-    public static List<BigQueryError> errorsOf(com.google.cloud.bigquery.BigQueryException exception, boolean inferRetryableReason) {
-        return errorsOrSynthetic(
-            exception.getErrors(),
-            reasonOf(exception, inferRetryableReason),
-            exception.getLocation(),
-            exception
-        );
+    public static List<BigQueryError> errorsOf(com.google.cloud.bigquery.BigQueryException exception) {
+        return errorsOrSynthetic(exception.getErrors(), exception.getReason(), exception.getLocation(), exception);
     }
 
-    /** {@link Job#waitFor} raises a JobException, which carries no HTTP status to derive a reason from. */
+    /** {@link Job#waitFor} raises a JobException, which carries neither reason nor location. */
     public static List<BigQueryError> errorsOf(JobException exception) {
-        return errorsOrSynthetic(exception.getErrors(), UNKNOWN_REASON, null, exception);
+        return errorsOrSynthetic(exception.getErrors(), null, null, exception);
     }
 
     private static List<BigQueryError> errorsOrSynthetic(List<BigQueryError> errors, String reason, String location, Throwable exception) {
@@ -89,26 +83,7 @@ public class BigQueryService {
             return errors;
         }
 
-        return List.of(new BigQueryError(reason, location, messageOf(exception)));
-    }
-
-    private static String reasonOf(com.google.cloud.bigquery.BigQueryException exception, boolean inferRetryableReason) {
-        if (exception.getReason() != null) {
-            return exception.getReason();
-        }
-
-        if (!inferRetryableReason) {
-            return UNKNOWN_REASON;
-        }
-
-        // No structured payload: derive the reason from the status so retryReasons still match.
-        // A bare 403 stays unknown on purpose: it is far more often a permission denial than a quota.
-        return switch (exception.getCode()) {
-            case 429 -> "rateLimitExceeded";
-            case 500 -> "internalError";
-            case 502, 503, 504 -> "backendError";
-            default -> UNKNOWN_REASON;
-        };
+        return List.of(new BigQueryError(Objects.requireNonNullElse(reason, UNKNOWN_REASON), location, messageOf(exception)));
     }
 
     private static String messageOf(Throwable exception) {

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryService.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryService.java
@@ -2,12 +2,14 @@ package io.kestra.plugin.gcp.bigquery;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.slf4j.Logger;
 
 import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobException;
 import com.google.cloud.bigquery.JobId;
 import com.google.cloud.bigquery.TableId;
 
@@ -56,6 +58,59 @@ public class BigQueryService {
                 throw new BigQueryException(errors);
             }
         }
+    }
+
+    /**
+     * BigQuery only populates the error list for job-level failures. Transport failures (a 5xx on the
+     * REST call, a socket error, an interrupted poll) arrive as a BigQueryException whose error list is
+     * null, so the code, reason and message must be folded into a synthetic error. Without it the
+     * failure surfaces as an empty "Bigquery Errors [ - ]" and the retry policy has nothing to match on.
+     */
+    public static List<BigQueryError> errorsOf(com.google.cloud.bigquery.BigQueryException exception) {
+        List<BigQueryError> errors = exception.getErrors();
+
+        if (errors != null && !errors.isEmpty()) {
+            return errors;
+        }
+
+        return List.of(new BigQueryError(reasonOf(exception), exception.getLocation(), messageOf(exception)));
+    }
+
+    /**
+     * Same as {@link #errorsOf(com.google.cloud.bigquery.BigQueryException)} for the job-level exception
+     * raised by {@link Job#waitFor}, which carries no HTTP code to map a reason from.
+     */
+    public static List<BigQueryError> errorsOf(JobException exception) {
+        List<BigQueryError> errors = exception.getErrors();
+
+        if (errors != null && !errors.isEmpty()) {
+            return errors;
+        }
+
+        return List.of(new BigQueryError("unknown", null, messageOf(exception)));
+    }
+
+    private static String reasonOf(com.google.cloud.bigquery.BigQueryException exception) {
+        if (exception.getReason() != null) {
+            return exception.getReason();
+        }
+
+        // Reason is only set when BigQuery answered with a structured error payload. Otherwise derive it
+        // from the HTTP status so that the default retryReasons still apply to transient failures.
+        return switch (exception.getCode()) {
+            case 429 -> "rateLimitExceeded";
+            case 500 -> "internalError";
+            case 502, 503, 504 -> "backendError";
+            default -> "unknown";
+        };
+    }
+
+    private static String messageOf(Throwable exception) {
+        if (exception.getMessage() != null && !exception.getMessage().isBlank()) {
+            return exception.getMessage();
+        }
+
+        return exception.getCause() != null ? exception.getCause().toString() : exception.toString();
     }
 
     public static Map<String, String> labels(RunContext runContext) {

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryService.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryService.java
@@ -17,6 +17,8 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.runners.RunContext;
 
 public class BigQueryService {
+    private static final String UNKNOWN_REASON = "unknown";
+
     public static JobId jobId(RunContext runContext, AbstractBigquery abstractBigquery) throws IllegalVariableEvaluationException {
         return JobId.newBuilder()
             .setProject(runContext.render(abstractBigquery.getProjectId()).as(String.class).orElse(null))
@@ -61,47 +63,51 @@ public class BigQueryService {
     }
 
     /**
-     * BigQuery only populates the error list for job-level failures. Transport failures (a 5xx on the
-     * REST call, a socket error, an interrupted poll) arrive as a BigQueryException whose error list is
-     * null, so the code, reason and message must be folded into a synthetic error. Without it the
-     * failure surfaces as an empty "Bigquery Errors [ - ]" and the retry policy has nothing to match on.
+     * BigQuery fills the error list only for job-level failures. A transport failure (bare 5xx, socket
+     * error, interrupted poll) arrives with it null, so fold the exception's own reason and message into
+     * one error: otherwise the failure reads as "Bigquery Errors [ - ]" and retryReasons has no match.
+     *
+     * @param inferRetryableReason derive a reason from the HTTP status when BigQuery returned none.
+     *        Only pass true where a retry can be deduplicated.
      */
-    public static List<BigQueryError> errorsOf(com.google.cloud.bigquery.BigQueryException exception) {
-        List<BigQueryError> errors = exception.getErrors();
-
-        if (errors != null && !errors.isEmpty()) {
-            return errors;
-        }
-
-        return List.of(new BigQueryError(reasonOf(exception), exception.getLocation(), messageOf(exception)));
+    public static List<BigQueryError> errorsOf(com.google.cloud.bigquery.BigQueryException exception, boolean inferRetryableReason) {
+        return errorsOrSynthetic(
+            exception.getErrors(),
+            reasonOf(exception, inferRetryableReason),
+            exception.getLocation(),
+            exception
+        );
     }
 
-    /**
-     * Same as {@link #errorsOf(com.google.cloud.bigquery.BigQueryException)} for the job-level exception
-     * raised by {@link Job#waitFor}, which carries no HTTP code to map a reason from.
-     */
+    /** {@link Job#waitFor} raises a JobException, which carries no HTTP status to derive a reason from. */
     public static List<BigQueryError> errorsOf(JobException exception) {
-        List<BigQueryError> errors = exception.getErrors();
+        return errorsOrSynthetic(exception.getErrors(), UNKNOWN_REASON, null, exception);
+    }
 
+    private static List<BigQueryError> errorsOrSynthetic(List<BigQueryError> errors, String reason, String location, Throwable exception) {
         if (errors != null && !errors.isEmpty()) {
             return errors;
         }
 
-        return List.of(new BigQueryError("unknown", null, messageOf(exception)));
+        return List.of(new BigQueryError(reason, location, messageOf(exception)));
     }
 
-    private static String reasonOf(com.google.cloud.bigquery.BigQueryException exception) {
+    private static String reasonOf(com.google.cloud.bigquery.BigQueryException exception, boolean inferRetryableReason) {
         if (exception.getReason() != null) {
             return exception.getReason();
         }
 
-        // Reason is only set when BigQuery answered with a structured error payload. Otherwise derive it
-        // from the HTTP status so that the default retryReasons still apply to transient failures.
+        if (!inferRetryableReason) {
+            return UNKNOWN_REASON;
+        }
+
+        // No structured payload: derive the reason from the status so retryReasons still match.
+        // A bare 403 stays unknown on purpose: it is far more often a permission denial than a quota.
         return switch (exception.getCode()) {
             case 429 -> "rateLimitExceeded";
             case 500 -> "internalError";
             case 502, 503, 504 -> "backendError";
-            default -> "unknown";
+            default -> UNKNOWN_REASON;
         };
     }
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/ExtractToGcs.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/ExtractToGcs.java
@@ -13,6 +13,7 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.executions.metrics.Timer;
 import io.kestra.core.models.property.Property;
@@ -23,7 +24,6 @@ import io.kestra.core.serializers.JacksonMapper;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -131,20 +131,23 @@ public class ExtractToGcs extends AbstractBigquery implements RunnableTask<Extra
 
         ExtractJobConfiguration configuration = this.buildExtractJob(runContext);
 
-        Job extractJob = connection.create(JobInfo.of(configuration));
-        this.trackJob(connection, extractJob.getJobId(), logger);
-
         logger.debug("Starting query\n{}", JacksonMapper.log(configuration));
 
-        return this.execute(runContext, logger, configuration, extractJob);
+        // Goes through waitForJob like the other job tasks, rather than polling the job directly: it is
+        // what tracks the job for cancellation, retries retryable failures, and re-attaches to the
+        // already-submitted job instead of submitting a second extract.
+        Job extractJob = this.waitForJob(
+            logger,
+            () -> connection.create(JobInfo.of(configuration)),
+            runContext,
+            connection
+        );
+
+        return this.execute(runContext, configuration, extractJob);
     }
 
-    protected ExtractToGcs.Output execute(RunContext runContext, Logger logger, ExtractJobConfiguration configuration, Job job)
-        throws InterruptedException, IllegalVariableEvaluationException, BigQueryException {
-        BigQueryService.handleErrors(job, logger);
-        job = job.waitFor();
-        BigQueryService.handleErrors(job, logger);
-
+    protected ExtractToGcs.Output execute(RunContext runContext, ExtractJobConfiguration configuration, Job job)
+        throws IllegalVariableEvaluationException {
         JobStatistics.ExtractStatistics stats = job.getStatistics();
         this.metrics(runContext, stats, job);
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/ExtractToGcs.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/ExtractToGcs.java
@@ -133,9 +133,8 @@ public class ExtractToGcs extends AbstractBigquery implements RunnableTask<Extra
 
         logger.debug("Starting query\n{}", JacksonMapper.log(configuration));
 
-        // Goes through waitForJob like the other job tasks, rather than polling the job directly: it is
-        // what tracks the job for cancellation, retries retryable failures, and re-attaches to the
-        // already-submitted job instead of submitting a second extract.
+        // waitForJob, like the other job tasks: tracks the job for cancellation, retries transient
+        // failures, and re-attaches to the submitted job instead of extracting twice.
         Job extractJob = this.waitForJob(
             logger,
             () -> connection.create(JobInfo.of(configuration)),
@@ -143,10 +142,10 @@ public class ExtractToGcs extends AbstractBigquery implements RunnableTask<Extra
             connection
         );
 
-        return this.execute(runContext, configuration, extractJob);
+        return this.outputs(runContext, configuration, extractJob);
     }
 
-    protected ExtractToGcs.Output execute(RunContext runContext, ExtractJobConfiguration configuration, Job job)
+    private ExtractToGcs.Output outputs(RunContext runContext, ExtractJobConfiguration configuration, Job job)
         throws IllegalVariableEvaluationException {
         JobStatistics.ExtractStatistics stats = job.getStatistics();
         this.metrics(runContext, stats, job);

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
@@ -364,7 +364,8 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
                 try {
                     return queryJob.getQueryResults();
                 } catch (com.google.cloud.bigquery.BigQueryException e) {
-                    throw new BigQueryException(BigQueryService.errorsOf(e), e);
+                    // Safe to infer a retryable reason: re-reading a finished job's results has no side effect.
+                    throw new BigQueryException(BigQueryService.errorsOf(e, true), e);
                 }
             });
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
@@ -19,15 +19,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.cloud.bigquery.*;
 import com.google.common.collect.ImmutableMap;
 
-import dev.failsafe.Failsafe;
-import io.kestra.core.models.property.Property;
-import io.kestra.core.models.tasks.common.FetchType;
-import io.kestra.core.models.tasks.retrys.AbstractRetry;
-import io.kestra.core.models.tasks.retrys.Exponential;
-import io.kestra.core.serializers.JacksonMapper;
-import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.*;
-import lombok.experimental.SuperBuilder;
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
@@ -38,10 +29,13 @@ import io.kestra.core.models.executions.metrics.Timer;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.RunnableTask;
 import io.kestra.core.models.tasks.common.FetchType;
+import io.kestra.core.models.tasks.retrys.AbstractRetry;
+import io.kestra.core.models.tasks.retrys.Exponential;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.serializers.FileSerde;
 import io.kestra.core.serializers.JacksonMapper;
 
+import dev.failsafe.Failsafe;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
@@ -337,47 +331,40 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
             .jobId(queryJob.getJobId().getJob());
 
         if (!FetchType.NONE.equals(fetchTypeRendered)) {
-            var retryConfig = this.getRetryAuto() != null ? this.getRetryAuto() : Exponential.builder()
-                .type("exponential")
-                .interval(Duration.ofSeconds(5))
-                .maxInterval(Duration.ofMinutes(60))
-                .maxDuration(Duration.ofMinutes(15))
-                .maxAttempts(10)
-                .build();
+            var retryConfig = this.getRetryAuto() != null ? this.getRetryAuto()
+                : Exponential.builder()
+                    .type("exponential")
+                    .interval(Duration.ofSeconds(5))
+                    .maxInterval(Duration.ofMinutes(60))
+                    .maxDuration(Duration.ofMinutes(15))
+                    .maxAttempts(10)
+                    .build();
 
             TableResult result = Failsafe.with(
-                AbstractRetry.<TableResult>retryPolicy(retryConfig)
+                AbstractRetry.<TableResult> retryPolicy(retryConfig)
                     .handleIf(throwable -> this.shouldRetry(throwable, logger, runContext))
-                    .onFailure(event -> logger.error(
-                        "Stop retry fetching query results, attempts {} elapsed {} seconds",
-                        event.getAttemptCount(),
-                        event.getElapsedTime().getSeconds(),
-                        event.getException()
-                    ))
-                    .onRetry(event -> logger.warn(
-                        "Retrying fetching query results, attempts {} elapsed {} seconds",
-                        event.getAttemptCount(),
-                        event.getElapsedTime().getSeconds()
-                    ))
+                    .onFailure(
+                        event -> logger.error(
+                            "Stop retry fetching query results, attempts {} elapsed {} seconds",
+                            event.getAttemptCount(),
+                            event.getElapsedTime().getSeconds(),
+                            event.getException()
+                        )
+                    )
+                    .onRetry(
+                        event -> logger.warn(
+                            "Retrying fetching query results, attempts {} elapsed {} seconds",
+                            event.getAttemptCount(),
+                            event.getElapsedTime().getSeconds()
+                        )
+                    )
                     .build()
-            ).get(() -> {
+            ).get(() ->
+            {
                 try {
                     return queryJob.getQueryResults();
                 } catch (com.google.cloud.bigquery.BigQueryException e) {
-                    List<BigQueryError> errors = e.getErrors();
-                    if (errors == null || errors.isEmpty()) {
-                        String reason = e.getReason();
-                        if (reason == null) {
-                            reason = switch (e.getCode()) {
-                                case 503 -> "backendError";
-                                case 500 -> "internalError";
-                                case 429 -> "rateLimitExceeded";
-                                default -> "unknown";
-                            };
-                        }
-                        errors = List.of(new BigQueryError(reason, e.getLocation(), e.getMessage()));
-                    }
-                    throw new BigQueryException(errors);
+                    throw new BigQueryException(BigQueryService.errorsOf(e), e);
                 }
             });
 
@@ -410,7 +397,6 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
                 }
             }
         }
-
 
         if (tableIdentity != null) {
             DestinationTable destinationTable = new DestinationTable(tableIdentity.getProject(), tableIdentity.getDataset(), tableIdentity.getTable());

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
@@ -364,8 +364,8 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
                 try {
                     return queryJob.getQueryResults();
                 } catch (com.google.cloud.bigquery.BigQueryException e) {
-                    // Safe to infer a retryable reason: re-reading a finished job's results has no side effect.
-                    throw new BigQueryException(BigQueryService.errorsOf(e, true), e);
+                    // Re-reading a finished job's results has no side effect, so the client's verdict stands.
+                    throw new BigQueryException(BigQueryService.errorsOf(e), e, e.isRetryable());
                 }
             });
 

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/BigQueryTransientErrorTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/BigQueryTransientErrorTest.java
@@ -7,16 +7,20 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mockito;
 
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryError;
+import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobId;
+import com.google.cloud.bigquery.JobStatus;
 import com.google.common.collect.ImmutableMap;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.retrys.Exponential;
-import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.utils.TestsUtils;
 
@@ -28,12 +32,11 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
- * BigQuery reports job-level problems in an error list, but transport problems (a 5xx on the REST call,
- * a socket error, an interrupted poll) come back with that list null. Those used to be rethrown as an
- * empty "Bigquery Errors [ - ]" with no cause and no reason to retry on.
+ * Transport failures carry no error list, and used to be rethrown as an empty "Bigquery Errors [ - ]".
  *
  * @see <a href="https://github.com/kestra-io/plugin-gcp/issues/675">#675</a>
  */
@@ -44,18 +47,39 @@ class BigQueryTransientErrorTest {
 
     @AfterEach
     void clearInterruptFlag() {
-        // waitForJob restores the interrupt flag on the calling thread, and JUnit reuses it for the next test.
+        // waitForJob restores the interrupt flag, and JUnit reuses this thread.
         Thread.interrupted();
     }
 
-    @Test
-    void shouldDeriveRetryableReasonFromHttpStatusWhenErrorListIsMissing() {
-        var exception = new com.google.cloud.bigquery.BigQueryException(503, "The service is currently unavailable.");
+    @ParameterizedTest
+    @CsvSource(
+        {
+            "429, rateLimitExceeded",
+            "500, internalError",
+            "502, backendError",
+            "503, backendError",
+            "504, backendError",
+            "403, unknown",
+            "400, unknown"
+        }
+    )
+    void shouldDeriveTheReasonFromTheHttpStatusWhenTheErrorListIsMissing(int code, String expectedReason) {
+        var exception = new com.google.cloud.bigquery.BigQueryException(code, "boom");
 
-        List<BigQueryError> errors = BigQueryService.errorsOf(exception);
+        List<BigQueryError> errors = BigQueryService.errorsOf(exception, true);
 
         assertThat(errors, hasSize(1));
-        assertThat(errors.getFirst().getReason(), is("backendError"));
+        assertThat(errors.getFirst().getReason(), is(expectedReason));
+        assertThat(errors.getFirst().getMessage(), is("boom"));
+    }
+
+    @Test
+    void shouldNotInferAReasonWhenARetryCannotBeDeduplicated() {
+        var exception = new com.google.cloud.bigquery.BigQueryException(503, "The service is currently unavailable.");
+
+        List<BigQueryError> errors = BigQueryService.errorsOf(exception, false);
+
+        assertThat(errors.getFirst().getReason(), is("unknown"));
         assertThat(errors.getFirst().getMessage(), is("The service is currently unavailable."));
     }
 
@@ -64,7 +88,7 @@ class BigQueryTransientErrorTest {
         var cause = new IOException("Connection reset");
         var exception = new com.google.cloud.bigquery.BigQueryException(0, null, cause);
 
-        List<BigQueryError> errors = BigQueryService.errorsOf(exception);
+        List<BigQueryError> errors = BigQueryService.errorsOf(exception, true);
 
         assertThat(errors, hasSize(1));
         assertThat(errors.getFirst().getReason(), is("unknown"));
@@ -76,73 +100,134 @@ class BigQueryTransientErrorTest {
         var reported = new BigQueryError("invalidQuery", null, "Syntax error");
         var exception = new com.google.cloud.bigquery.BigQueryException(400, "Syntax error", reported);
 
-        assertThat(BigQueryService.errorsOf(exception), is(List.of(reported)));
+        assertThat(BigQueryService.errorsOf(exception, true), is(List.of(reported)));
     }
 
     @Test
-    void shouldReportTheJobIdAndStopRetryingWhenTheWaitIsInterrupted() throws Exception {
-        Query task = task();
-        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
-        BigQuery connection = Mockito.mock(BigQuery.class);
-        AtomicInteger submissions = new AtomicInteger();
+    void shouldNotRetryASubmissionThatFailedWithoutAnErrorList() throws Exception {
+        var task = task();
+        var runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+        var submissions = new AtomicInteger();
 
-        // How the client surfaces an interrupt raised while polling: no error list, no HTTP code.
-        var interrupted = new com.google.cloud.bigquery.BigQueryException(
-            0,
-            "java.lang.InterruptedException",
-            new InterruptedException()
-        );
+        // Nothing here can tell an accepted job from a lost one, so a retry could run the statement twice.
+        var unavailable = new com.google.cloud.bigquery.BigQueryException(503, "The service is currently unavailable.");
 
-        FailsafeException thrown = assertThrows(
+        var thrown = assertThrows(
             FailsafeException.class, () -> task.waitForJob(
                 runContext.logger(),
                 () ->
                 {
                     submissions.incrementAndGet();
-                    throw interrupted;
+                    throw unavailable;
                 },
                 runContext,
-                connection
+                Mockito.mock(BigQuery.class)
             )
         );
 
-        assertThat(thrown.getCause(), instanceOf(BigQueryException.class));
-        BigQueryException failure = (BigQueryException) thrown.getCause();
+        var failure = (BigQueryException) thrown.getCause();
+
+        assertThat(failure.getErrors().getFirst().getReason(), is("unknown"));
+        assertThat(failure.getMessage(), containsString("The service is currently unavailable."));
+        assertThat(failure.getCause(), is(unavailable));
+        assertThat(submissions.get(), is(1));
+    }
+
+    @Test
+    void shouldNameTheJobAndStopRetryingWhenThePollIsInterrupted() throws Exception {
+        var task = task();
+        var runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+        var submissions = new AtomicInteger();
+
+        // Job#waitFor declares InterruptedException raw, on top of the wrapped shape the client also uses.
+        var job = runningJob("job_interrupted");
+        Mockito.when(job.waitFor()).thenThrow(new InterruptedException());
+
+        var thrown = assertThrows(
+            FailsafeException.class, () -> task.waitForJob(
+                runContext.logger(),
+                () ->
+                {
+                    submissions.incrementAndGet();
+                    return job;
+                },
+                runContext,
+                Mockito.mock(BigQuery.class)
+            )
+        );
+
+        var failure = (BigQueryException) thrown.getCause();
 
         assertThat(failure.getErrors(), hasSize(1));
         assertThat(failure.getErrors().getFirst().getReason(), is("interrupted"));
+        assertThat(failure.getErrors().getFirst().getMessage(), containsString("'job_interrupted'"));
         assertThat(failure.getErrors().getFirst().getMessage(), containsString("may still be running on BigQuery"));
-        assertThat(failure.getCause(), is(interrupted));
 
-        // An interrupted thread cannot make progress, so the submission must not be replayed.
+        // An interrupted thread cannot make progress: no replay.
         assertThat(submissions.get(), is(1));
         assertThat(Thread.currentThread().isInterrupted(), is(true));
     }
 
     @Test
-    void shouldKeepTheOriginalExceptionAsTheCauseOfAnErrorlessFailure() throws Exception {
-        Query task = task();
-        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
-        BigQuery connection = Mockito.mock(BigQuery.class);
+    void shouldSayTheJobWasCancelledWhenTheTaskWasKilledFirst() throws Exception {
+        var task = task();
+        var runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
 
-        var unavailable = new com.google.cloud.bigquery.BigQueryException(503, "The service is currently unavailable.");
+        task.kill();
 
-        FailsafeException thrown = assertThrows(
+        var thrown = assertThrows(
             FailsafeException.class, () -> task.waitForJob(
                 runContext.logger(),
                 () ->
                 {
-                    throw unavailable;
+                    throw new com.google.cloud.bigquery.BigQueryException(0, "java.lang.InterruptedException", new InterruptedException());
                 },
                 runContext,
-                connection
+                Mockito.mock(BigQuery.class)
             )
         );
 
-        BigQueryException failure = (BigQueryException) thrown.getCause();
+        var failure = (BigQueryException) thrown.getCause();
 
+        assertThat(failure.getErrors().getFirst().getMessage(), containsString("the job was cancelled"));
+        assertThat(failure.getErrors().getFirst().getMessage(), not(containsString("may still be running")));
+    }
+
+    @Test
+    void shouldKeepTheOriginalExceptionAsTheCauseOfAnErrorlessPollFailure() throws Exception {
+        var task = task();
+        var runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        var unavailable = new com.google.cloud.bigquery.BigQueryException(503, "The service is currently unavailable.");
+        var job = runningJob("job_poll_failed");
+        Mockito.when(job.waitFor()).thenThrow(unavailable);
+
+        var thrown = assertThrows(
+            FailsafeException.class, () -> task.waitForJob(
+                runContext.logger(),
+                () -> job,
+                runContext,
+                Mockito.mock(BigQuery.class)
+            )
+        );
+
+        var failure = (BigQueryException) thrown.getCause();
+
+        assertThat(failure.getCause(), instanceOf(com.google.cloud.bigquery.BigQueryException.class));
         assertThat(failure.getMessage(), containsString("The service is currently unavailable."));
-        assertThat(failure.getCause(), is(unavailable));
+        // The job id is known here, so the reason is inferred and the retry policy can act on it.
+        assertThat(failure.getErrors().getFirst().getReason(), is("backendError"));
+    }
+
+    private Job runningJob(String id) {
+        var status = Mockito.mock(JobStatus.class);
+        Mockito.when(status.getError()).thenReturn(null);
+
+        var job = Mockito.mock(Job.class);
+        Mockito.when(job.getJobId()).thenReturn(JobId.of("project", id));
+        Mockito.when(job.getStatus()).thenReturn(status);
+
+        return job;
     }
 
     private Query task() {

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/BigQueryTransientErrorTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/BigQueryTransientErrorTest.java
@@ -1,0 +1,164 @@
+package io.kestra.plugin.gcp.bigquery;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryError;
+import com.google.common.collect.ImmutableMap;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.models.tasks.retrys.Exponential;
+import io.kestra.core.runners.RunContext;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.TestsUtils;
+
+import dev.failsafe.FailsafeException;
+import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * BigQuery reports job-level problems in an error list, but transport problems (a 5xx on the REST call,
+ * a socket error, an interrupted poll) come back with that list null. Those used to be rethrown as an
+ * empty "Bigquery Errors [ - ]" with no cause and no reason to retry on.
+ *
+ * @see <a href="https://github.com/kestra-io/plugin-gcp/issues/675">#675</a>
+ */
+@KestraTest
+class BigQueryTransientErrorTest {
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @AfterEach
+    void clearInterruptFlag() {
+        // waitForJob restores the interrupt flag on the calling thread, and JUnit reuses it for the next test.
+        Thread.interrupted();
+    }
+
+    @Test
+    void shouldDeriveRetryableReasonFromHttpStatusWhenErrorListIsMissing() {
+        var exception = new com.google.cloud.bigquery.BigQueryException(503, "The service is currently unavailable.");
+
+        List<BigQueryError> errors = BigQueryService.errorsOf(exception);
+
+        assertThat(errors, hasSize(1));
+        assertThat(errors.getFirst().getReason(), is("backendError"));
+        assertThat(errors.getFirst().getMessage(), is("The service is currently unavailable."));
+    }
+
+    @Test
+    void shouldFallBackToTheCauseWhenTheExceptionCarriesNoMessage() {
+        var cause = new IOException("Connection reset");
+        var exception = new com.google.cloud.bigquery.BigQueryException(0, null, cause);
+
+        List<BigQueryError> errors = BigQueryService.errorsOf(exception);
+
+        assertThat(errors, hasSize(1));
+        assertThat(errors.getFirst().getReason(), is("unknown"));
+        assertThat(errors.getFirst().getMessage(), containsString("Connection reset"));
+    }
+
+    @Test
+    void shouldKeepTheReportedErrorListUntouched() {
+        var reported = new BigQueryError("invalidQuery", null, "Syntax error");
+        var exception = new com.google.cloud.bigquery.BigQueryException(400, "Syntax error", reported);
+
+        assertThat(BigQueryService.errorsOf(exception), is(List.of(reported)));
+    }
+
+    @Test
+    void shouldReportTheJobIdAndStopRetryingWhenTheWaitIsInterrupted() throws Exception {
+        Query task = task();
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+        BigQuery connection = Mockito.mock(BigQuery.class);
+        AtomicInteger submissions = new AtomicInteger();
+
+        // How the client surfaces an interrupt raised while polling: no error list, no HTTP code.
+        var interrupted = new com.google.cloud.bigquery.BigQueryException(
+            0,
+            "java.lang.InterruptedException",
+            new InterruptedException()
+        );
+
+        FailsafeException thrown = assertThrows(
+            FailsafeException.class, () -> task.waitForJob(
+                runContext.logger(),
+                () ->
+                {
+                    submissions.incrementAndGet();
+                    throw interrupted;
+                },
+                runContext,
+                connection
+            )
+        );
+
+        assertThat(thrown.getCause(), instanceOf(BigQueryException.class));
+        BigQueryException failure = (BigQueryException) thrown.getCause();
+
+        assertThat(failure.getErrors(), hasSize(1));
+        assertThat(failure.getErrors().getFirst().getReason(), is("interrupted"));
+        assertThat(failure.getErrors().getFirst().getMessage(), containsString("may still be running on BigQuery"));
+        assertThat(failure.getCause(), is(interrupted));
+
+        // An interrupted thread cannot make progress, so the submission must not be replayed.
+        assertThat(submissions.get(), is(1));
+        assertThat(Thread.currentThread().isInterrupted(), is(true));
+    }
+
+    @Test
+    void shouldKeepTheOriginalExceptionAsTheCauseOfAnErrorlessFailure() throws Exception {
+        Query task = task();
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+        BigQuery connection = Mockito.mock(BigQuery.class);
+
+        var unavailable = new com.google.cloud.bigquery.BigQueryException(503, "The service is currently unavailable.");
+
+        FailsafeException thrown = assertThrows(
+            FailsafeException.class, () -> task.waitForJob(
+                runContext.logger(),
+                () ->
+                {
+                    throw unavailable;
+                },
+                runContext,
+                connection
+            )
+        );
+
+        BigQueryException failure = (BigQueryException) thrown.getCause();
+
+        assertThat(failure.getMessage(), containsString("The service is currently unavailable."));
+        assertThat(failure.getCause(), is(unavailable));
+    }
+
+    private Query task() {
+        return Query.builder()
+            .id(BigQueryTransientErrorTest.class.getSimpleName())
+            .type(Query.class.getName())
+            .sql(Property.ofValue("SELECT 1"))
+            .retryAuto(
+                Exponential.builder()
+                    .type("exponential")
+                    .interval(Duration.ofMillis(10))
+                    .maxInterval(Duration.ofMillis(50))
+                    .maxDuration(Duration.ofSeconds(5))
+                    .maxAttempts(3)
+                    .build()
+            )
+            .build();
+    }
+}

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/BigQueryTransientErrorTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/BigQueryTransientErrorTest.java
@@ -1,14 +1,13 @@
 package io.kestra.plugin.gcp.bigquery;
 
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mockito;
 
 import com.google.cloud.bigquery.BigQuery;
@@ -51,34 +50,13 @@ class BigQueryTransientErrorTest {
         Thread.interrupted();
     }
 
-    @ParameterizedTest
-    @CsvSource(
-        {
-            "429, rateLimitExceeded",
-            "500, internalError",
-            "502, backendError",
-            "503, backendError",
-            "504, backendError",
-            "403, unknown",
-            "400, unknown"
-        }
-    )
-    void shouldDeriveTheReasonFromTheHttpStatusWhenTheErrorListIsMissing(int code, String expectedReason) {
-        var exception = new com.google.cloud.bigquery.BigQueryException(code, "boom");
-
-        List<BigQueryError> errors = BigQueryService.errorsOf(exception, true);
-
-        assertThat(errors, hasSize(1));
-        assertThat(errors.getFirst().getReason(), is(expectedReason));
-        assertThat(errors.getFirst().getMessage(), is("boom"));
-    }
-
     @Test
-    void shouldNotInferAReasonWhenARetryCannotBeDeduplicated() {
+    void shouldCarryTheMessageWhenTheErrorListIsMissing() {
         var exception = new com.google.cloud.bigquery.BigQueryException(503, "The service is currently unavailable.");
 
-        List<BigQueryError> errors = BigQueryService.errorsOf(exception, false);
+        List<BigQueryError> errors = BigQueryService.errorsOf(exception);
 
+        assertThat(errors, hasSize(1));
         assertThat(errors.getFirst().getReason(), is("unknown"));
         assertThat(errors.getFirst().getMessage(), is("The service is currently unavailable."));
     }
@@ -88,10 +66,9 @@ class BigQueryTransientErrorTest {
         var cause = new IOException("Connection reset");
         var exception = new com.google.cloud.bigquery.BigQueryException(0, null, cause);
 
-        List<BigQueryError> errors = BigQueryService.errorsOf(exception, true);
+        List<BigQueryError> errors = BigQueryService.errorsOf(exception);
 
         assertThat(errors, hasSize(1));
-        assertThat(errors.getFirst().getReason(), is("unknown"));
         assertThat(errors.getFirst().getMessage(), containsString("Connection reset"));
     }
 
@@ -100,7 +77,39 @@ class BigQueryTransientErrorTest {
         var reported = new BigQueryError("invalidQuery", null, "Syntax error");
         var exception = new com.google.cloud.bigquery.BigQueryException(400, "Syntax error", reported);
 
-        assertThat(BigQueryService.errorsOf(exception, true), is(List.of(reported)));
+        assertThat(BigQueryService.errorsOf(exception), is(List.of(reported)));
+    }
+
+    @Test
+    void shouldTrustTheClientVerdictOnceTheJobIdIsKnown() throws Exception {
+        var task = task();
+        var runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        var unavailable = new com.google.cloud.bigquery.BigQueryException(503, "The service is currently unavailable.");
+        var job = runningJob("job_poll_failed");
+        Mockito.when(job.waitFor()).thenThrow(unavailable);
+
+        var failure = failureOf(task, runContext, () -> job);
+
+        assertThat(failure.isRetryable(), is(true));
+        assertThat(failure.getCause(), instanceOf(com.google.cloud.bigquery.BigQueryException.class));
+        assertThat(failure.getMessage(), containsString("The service is currently unavailable."));
+    }
+
+    @Test
+    void shouldFollowTheClientVerdictRatherThanAnHttpStatus() throws Exception {
+        var task = task();
+        var runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        // A socket timeout has no HTTP status at all, yet the client reports it as worth retrying.
+        var job = runningJob("job_socket_timeout");
+        Mockito.when(job.waitFor())
+            .thenThrow(new com.google.cloud.bigquery.BigQueryException(new SocketTimeoutException("read timed out")));
+
+        var failure = failureOf(task, runContext, () -> job);
+
+        assertThat(failure.isRetryable(), is(true));
+        assertThat(failure.getMessage(), containsString("read timed out"));
     }
 
     @Test
@@ -112,22 +121,13 @@ class BigQueryTransientErrorTest {
         // Nothing here can tell an accepted job from a lost one, so a retry could run the statement twice.
         var unavailable = new com.google.cloud.bigquery.BigQueryException(503, "The service is currently unavailable.");
 
-        var thrown = assertThrows(
-            FailsafeException.class, () -> task.waitForJob(
-                runContext.logger(),
-                () ->
-                {
-                    submissions.incrementAndGet();
-                    throw unavailable;
-                },
-                runContext,
-                Mockito.mock(BigQuery.class)
-            )
-        );
+        var failure = failureOf(task, runContext, () ->
+        {
+            submissions.incrementAndGet();
+            throw unavailable;
+        });
 
-        var failure = (BigQueryException) thrown.getCause();
-
-        assertThat(failure.getErrors().getFirst().getReason(), is("unknown"));
+        assertThat(failure.isRetryable(), is(false));
         assertThat(failure.getMessage(), containsString("The service is currently unavailable."));
         assertThat(failure.getCause(), is(unavailable));
         assertThat(submissions.get(), is(1));
@@ -143,21 +143,13 @@ class BigQueryTransientErrorTest {
         var job = runningJob("job_interrupted");
         Mockito.when(job.waitFor()).thenThrow(new InterruptedException());
 
-        var thrown = assertThrows(
-            FailsafeException.class, () -> task.waitForJob(
-                runContext.logger(),
-                () ->
-                {
-                    submissions.incrementAndGet();
-                    return job;
-                },
-                runContext,
-                Mockito.mock(BigQuery.class)
-            )
-        );
+        var failure = failureOf(task, runContext, () ->
+        {
+            submissions.incrementAndGet();
+            return job;
+        });
 
-        var failure = (BigQueryException) thrown.getCause();
-
+        assertThat(failure.isRetryable(), is(false));
         assertThat(failure.getErrors(), hasSize(1));
         assertThat(failure.getErrors().getFirst().getReason(), is("interrupted"));
         assertThat(failure.getErrors().getFirst().getMessage(), containsString("'job_interrupted'"));
@@ -175,48 +167,26 @@ class BigQueryTransientErrorTest {
 
         task.kill();
 
-        var thrown = assertThrows(
-            FailsafeException.class, () -> task.waitForJob(
-                runContext.logger(),
-                () ->
-                {
-                    throw new com.google.cloud.bigquery.BigQueryException(0, "java.lang.InterruptedException", new InterruptedException());
-                },
-                runContext,
-                Mockito.mock(BigQuery.class)
-            )
-        );
-
-        var failure = (BigQueryException) thrown.getCause();
+        var failure = failureOf(task, runContext, () ->
+        {
+            throw new com.google.cloud.bigquery.BigQueryException(0, "java.lang.InterruptedException", new InterruptedException());
+        });
 
         assertThat(failure.getErrors().getFirst().getMessage(), containsString("the job was cancelled"));
         assertThat(failure.getErrors().getFirst().getMessage(), not(containsString("may still be running")));
     }
 
-    @Test
-    void shouldKeepTheOriginalExceptionAsTheCauseOfAnErrorlessPollFailure() throws Exception {
-        var task = task();
-        var runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
-
-        var unavailable = new com.google.cloud.bigquery.BigQueryException(503, "The service is currently unavailable.");
-        var job = runningJob("job_poll_failed");
-        Mockito.when(job.waitFor()).thenThrow(unavailable);
-
+    private BigQueryException failureOf(Query task, io.kestra.core.runners.RunContext runContext, java.util.concurrent.Callable<Job> createJob) {
         var thrown = assertThrows(
             FailsafeException.class, () -> task.waitForJob(
                 runContext.logger(),
-                () -> job,
+                createJob,
                 runContext,
                 Mockito.mock(BigQuery.class)
             )
         );
 
-        var failure = (BigQueryException) thrown.getCause();
-
-        assertThat(failure.getCause(), instanceOf(com.google.cloud.bigquery.BigQueryException.class));
-        assertThat(failure.getMessage(), containsString("The service is currently unavailable."));
-        // The job id is known here, so the reason is inferred and the retry policy can act on it.
-        assertThat(failure.getErrors().getFirst().getReason(), is("backendError"));
+        return (BigQueryException) thrown.getCause();
     }
 
     private Job runningJob(String id) {

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/QueryErrorTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/QueryErrorTest.java
@@ -1,5 +1,11 @@
 package io.kestra.plugin.gcp.bigquery;
 
+import java.time.Duration;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.github.tomakehurst.wiremock.stubbing.Scenario;
@@ -7,6 +13,7 @@ import com.google.cloud.NoCredentials;
 import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryOptions;
 import com.google.common.collect.ImmutableMap;
+
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
 import io.kestra.core.models.tasks.common.FetchType;
@@ -14,13 +21,9 @@ import io.kestra.core.models.tasks.retrys.Exponential;
 import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.utils.TestsUtils;
+
 import io.micronaut.context.annotation.Value;
 import jakarta.inject.Inject;
-import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
-import java.time.Duration;
-import java.util.Map;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -197,15 +200,78 @@ public class QueryErrorTest {
           }
         }""";
 
+    // BigQuery does not always answer with a structured "errors" array. A bare 5xx like this one leaves
+    // BigQueryException#getErrors() null, which used to surface as "Bigquery Errors [ - ]" with no reason
+    // to retry on, so the task failed while the job kept running to completion. See #675.
+    private static final String BACKEND_ERROR_RESPONSE_WITHOUT_ERROR_LIST = """
+        {
+          "error": {
+            "code": 503,
+            "message": "The service is currently unavailable.",
+            "status": "UNAVAILABLE"
+          }
+        }""";
+
+    @Test
+    void shouldRecoverWhenPollingFailsWithoutAnErrorList(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String jobsPath = "/bigquery/v2/projects/.*/jobs";
+        String pollingPath = "/bigquery/v2/projects/.*/queries/job_dup_test.*";
+        String jobStatusPath = "/bigquery/v2/projects/.*/jobs/job_dup_test.*";
+
+        stubFor(
+            post(urlPathMatching(jobsPath))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(JOB_RESPONSE_RUNNING)
+                )
+        );
+
+        // The poll fails with a transient error carrying no error list, even though the job succeeded.
+        stubFor(
+            get(urlPathMatching(pollingPath))
+                .willReturn(
+                    aResponse()
+                        .withStatus(503)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(BACKEND_ERROR_RESPONSE_WITHOUT_ERROR_LIST)
+                )
+        );
+
+        // The job's real status, fetched directly, shows it already completed successfully.
+        stubFor(
+            get(urlPathMatching(jobStatusPath))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(JOB_RESPONSE_DUP_TEST_DONE)
+                )
+        );
+
+        Query task = buildQueryWithoutFetch(wmRuntimeInfo, 3);
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        Query.Output output = task.run(runContext);
+
+        assertEquals("job_dup_test", output.getJobId());
+        verify(1, postRequestedFor(urlPathMatching(jobsPath)));
+    }
+
     @Test
     void shouldRetryOnBackendError(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         String jobsPath = "/bigquery/v2/projects/.*/jobs";
 
-        stubFor(post(urlPathMatching(jobsPath))
-            .willReturn(aResponse()
-                .withStatus(503)
-                .withHeader("Content-Type", "application/json")
-                .withBody(BACKEND_ERROR_RESPONSE)));
+        stubFor(
+            post(urlPathMatching(jobsPath))
+                .willReturn(
+                    aResponse()
+                        .withStatus(503)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(BACKEND_ERROR_RESPONSE)
+                )
+        );
 
         Query task = buildQuery(wmRuntimeInfo, 3);
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
@@ -221,24 +287,36 @@ public class QueryErrorTest {
         String resultsPath = "/bigquery/v2/projects/.*/queries/job_1234567890abcdef";
 
         // Job creation and polling succeed
-        stubFor(post(urlPathMatching(jobsPath))
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "application/json")
-                .withBody(JOB_RESPONSE_DONE)));
+        stubFor(
+            post(urlPathMatching(jobsPath))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(JOB_RESPONSE_DONE)
+                )
+        );
 
-        stubFor(get(urlPathMatching("/bigquery/v2/projects/.*/jobs/job_1234567890abcdef"))
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "application/json")
-                .withBody(JOB_RESPONSE_DONE)));
+        stubFor(
+            get(urlPathMatching("/bigquery/v2/projects/.*/jobs/job_1234567890abcdef"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(JOB_RESPONSE_DONE)
+                )
+        );
 
         // Result fetching returns 503
-        stubFor(get(urlPathMatching(resultsPath))
-            .willReturn(aResponse()
-                .withStatus(503)
-                .withHeader("Content-Type", "application/json")
-                .withBody(BACKEND_ERROR_RESPONSE)));
+        stubFor(
+            get(urlPathMatching(resultsPath))
+                .willReturn(
+                    aResponse()
+                        .withStatus(503)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(BACKEND_ERROR_RESPONSE)
+                )
+        );
 
         Query task = buildQuery(wmRuntimeInfo, 3);
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
@@ -260,25 +338,37 @@ public class QueryErrorTest {
         // our fix looks up the last submitted job's status via BigQuery#getJob(JobId), which hits jobs/{id}.
         String jobStatusPath = "/bigquery/v2/projects/.*/jobs/job_dup_test.*";
 
-        stubFor(post(urlPathMatching(jobsPath))
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "application/json")
-                .withBody(JOB_RESPONSE_RUNNING)));
+        stubFor(
+            post(urlPathMatching(jobsPath))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(JOB_RESPONSE_RUNNING)
+                )
+        );
 
         // The poll consistently fails with a transient error, even though the job actually succeeded.
-        stubFor(get(urlPathMatching(pollingPath))
-            .willReturn(aResponse()
-                .withStatus(503)
-                .withHeader("Content-Type", "application/json")
-                .withBody(BACKEND_ERROR_RESPONSE)));
+        stubFor(
+            get(urlPathMatching(pollingPath))
+                .willReturn(
+                    aResponse()
+                        .withStatus(503)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(BACKEND_ERROR_RESPONSE)
+                )
+        );
 
         // The job's real status, fetched directly, shows it already completed successfully.
-        stubFor(get(urlPathMatching(jobStatusPath))
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "application/json")
-                .withBody(JOB_RESPONSE_DUP_TEST_DONE)));
+        stubFor(
+            get(urlPathMatching(jobStatusPath))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(JOB_RESPONSE_DUP_TEST_DONE)
+                )
+        );
 
         Query task = buildQueryWithoutFetch(wmRuntimeInfo, 3);
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
@@ -295,37 +385,53 @@ public class QueryErrorTest {
         String pollingPath = "/bigquery/v2/projects/.*/queries/job_dup_test.*";
         String jobStatusPath = "/bigquery/v2/projects/.*/jobs/job_dup_test.*";
 
-        stubFor(post(urlPathMatching(jobsPath))
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "application/json")
-                .withBody(JOB_RESPONSE_RUNNING)));
+        stubFor(
+            post(urlPathMatching(jobsPath))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(JOB_RESPONSE_RUNNING)
+                )
+        );
 
         // The job's own first poll fails transiently; once the retry looks the job up directly and
         // finds it still running, it calls waitFor() again, which this time observes completion.
-        stubFor(get(urlPathMatching(pollingPath))
-            .inScenario("still-running")
-            .whenScenarioStateIs(Scenario.STARTED)
-            .willReturn(aResponse()
-                .withStatus(503)
-                .withHeader("Content-Type", "application/json")
-                .withBody(BACKEND_ERROR_RESPONSE))
-            .willSetStateTo("completed"));
+        stubFor(
+            get(urlPathMatching(pollingPath))
+                .inScenario("still-running")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(
+                    aResponse()
+                        .withStatus(503)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(BACKEND_ERROR_RESPONSE)
+                )
+                .willSetStateTo("completed")
+        );
 
-        stubFor(get(urlPathMatching(pollingPath))
-            .inScenario("still-running")
-            .whenScenarioStateIs("completed")
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "application/json")
-                .withBody(QUERY_RESULTS_RESPONSE_COMPLETE)));
+        stubFor(
+            get(urlPathMatching(pollingPath))
+                .inScenario("still-running")
+                .whenScenarioStateIs("completed")
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(QUERY_RESULTS_RESPONSE_COMPLETE)
+                )
+        );
 
         // The job's real status, fetched directly, shows it is still running.
-        stubFor(get(urlPathMatching(jobStatusPath))
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "application/json")
-                .withBody(JOB_RESPONSE_RUNNING)));
+        stubFor(
+            get(urlPathMatching(jobStatusPath))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(JOB_RESPONSE_RUNNING)
+                )
+        );
 
         Query task = buildQueryWithoutFetch(wmRuntimeInfo, 3);
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
@@ -347,50 +453,70 @@ public class QueryErrorTest {
         String pollingPath = "/bigquery/v2/projects/.*/queries/job_dup_test.*";
         String jobStatusPath = "/bigquery/v2/projects/.*/jobs/job_dup_test.*";
 
-        stubFor(post(urlPathMatching(jobsPath))
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "application/json")
-                .withBody(JOB_RESPONSE_RUNNING)));
+        stubFor(
+            post(urlPathMatching(jobsPath))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(JOB_RESPONSE_RUNNING)
+                )
+        );
 
         // The original job's poll fails transiently; the fresh job submitted after the lookback
         // then polls successfully.
-        stubFor(get(urlPathMatching(pollingPath))
-            .inScenario("done-with-error")
-            .whenScenarioStateIs(Scenario.STARTED)
-            .willReturn(aResponse()
-                .withStatus(503)
-                .withHeader("Content-Type", "application/json")
-                .withBody(BACKEND_ERROR_RESPONSE))
-            .willSetStateTo("completed"));
+        stubFor(
+            get(urlPathMatching(pollingPath))
+                .inScenario("done-with-error")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(
+                    aResponse()
+                        .withStatus(503)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(BACKEND_ERROR_RESPONSE)
+                )
+                .willSetStateTo("completed")
+        );
 
-        stubFor(get(urlPathMatching(pollingPath))
-            .inScenario("done-with-error")
-            .whenScenarioStateIs("completed")
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "application/json")
-                .withBody(QUERY_RESULTS_RESPONSE_COMPLETE)));
+        stubFor(
+            get(urlPathMatching(pollingPath))
+                .inScenario("done-with-error")
+                .whenScenarioStateIs("completed")
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(QUERY_RESULTS_RESPONSE_COMPLETE)
+                )
+        );
 
         // The job's real status, fetched directly, shows it actually failed: no dedup, a new job is submitted.
         // Job#waitFor() itself calls reload() (another GET on this same path) once the fresh job completes,
         // to fetch its authoritative final status, so the stub must distinguish that call from the lookback.
-        stubFor(get(urlPathMatching(jobStatusPath))
-            .inScenario("done-with-error-status")
-            .whenScenarioStateIs(Scenario.STARTED)
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "application/json")
-                .withBody(JOB_RESPONSE_DUP_TEST_DONE_WITH_ERROR))
-            .willSetStateTo("new-job-completed"));
+        stubFor(
+            get(urlPathMatching(jobStatusPath))
+                .inScenario("done-with-error-status")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(JOB_RESPONSE_DUP_TEST_DONE_WITH_ERROR)
+                )
+                .willSetStateTo("new-job-completed")
+        );
 
-        stubFor(get(urlPathMatching(jobStatusPath))
-            .inScenario("done-with-error-status")
-            .whenScenarioStateIs("new-job-completed")
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "application/json")
-                .withBody(JOB_RESPONSE_DUP_TEST_DONE)));
+        stubFor(
+            get(urlPathMatching(jobStatusPath))
+                .inScenario("done-with-error-status")
+                .whenScenarioStateIs("new-job-completed")
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(JOB_RESPONSE_DUP_TEST_DONE)
+                )
+        );
 
         Query task = buildQueryWithoutFetch(wmRuntimeInfo, 3);
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
@@ -407,50 +533,70 @@ public class QueryErrorTest {
         String pollingPath = "/bigquery/v2/projects/.*/queries/job_dup_test.*";
         String jobStatusPath = "/bigquery/v2/projects/.*/jobs/job_dup_test.*";
 
-        stubFor(post(urlPathMatching(jobsPath))
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "application/json")
-                .withBody(JOB_RESPONSE_RUNNING)));
+        stubFor(
+            post(urlPathMatching(jobsPath))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(JOB_RESPONSE_RUNNING)
+                )
+        );
 
         // The original job's poll fails transiently; the fresh job submitted after the lookback
         // then polls successfully.
-        stubFor(get(urlPathMatching(pollingPath))
-            .inScenario("not-found")
-            .whenScenarioStateIs(Scenario.STARTED)
-            .willReturn(aResponse()
-                .withStatus(503)
-                .withHeader("Content-Type", "application/json")
-                .withBody(BACKEND_ERROR_RESPONSE))
-            .willSetStateTo("completed"));
+        stubFor(
+            get(urlPathMatching(pollingPath))
+                .inScenario("not-found")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(
+                    aResponse()
+                        .withStatus(503)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(BACKEND_ERROR_RESPONSE)
+                )
+                .willSetStateTo("completed")
+        );
 
-        stubFor(get(urlPathMatching(pollingPath))
-            .inScenario("not-found")
-            .whenScenarioStateIs("completed")
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "application/json")
-                .withBody(QUERY_RESULTS_RESPONSE_COMPLETE)));
+        stubFor(
+            get(urlPathMatching(pollingPath))
+                .inScenario("not-found")
+                .whenScenarioStateIs("completed")
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(QUERY_RESULTS_RESPONSE_COMPLETE)
+                )
+        );
 
         // The job can no longer be found: no dedup, a new job is submitted.
         // Job#waitFor() itself calls reload() (another GET on this same path) once the fresh job completes,
         // to fetch its authoritative final status, so the stub must distinguish that call from the lookback.
-        stubFor(get(urlPathMatching(jobStatusPath))
-            .inScenario("not-found-status")
-            .whenScenarioStateIs(Scenario.STARTED)
-            .willReturn(aResponse()
-                .withStatus(404)
-                .withHeader("Content-Type", "application/json")
-                .withBody(JOB_NOT_FOUND_RESPONSE))
-            .willSetStateTo("new-job-completed"));
+        stubFor(
+            get(urlPathMatching(jobStatusPath))
+                .inScenario("not-found-status")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(
+                    aResponse()
+                        .withStatus(404)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(JOB_NOT_FOUND_RESPONSE)
+                )
+                .willSetStateTo("new-job-completed")
+        );
 
-        stubFor(get(urlPathMatching(jobStatusPath))
-            .inScenario("not-found-status")
-            .whenScenarioStateIs("new-job-completed")
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "application/json")
-                .withBody(JOB_RESPONSE_DUP_TEST_DONE)));
+        stubFor(
+            get(urlPathMatching(jobStatusPath))
+                .inScenario("not-found-status")
+                .whenScenarioStateIs("new-job-completed")
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(JOB_RESPONSE_DUP_TEST_DONE)
+                )
+        );
 
         Query task = buildQueryWithoutFetch(wmRuntimeInfo, 3);
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
@@ -469,22 +615,30 @@ public class QueryErrorTest {
 
         // A dry-run job is never polled, so its first submission fails with a job-level error that
         // is only visible once the job comes back as DONE; the retry submits a fresh dry-run job.
-        stubFor(post(urlPathMatching(jobsPath))
-            .inScenario("dry-run-retry")
-            .whenScenarioStateIs(Scenario.STARTED)
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "application/json")
-                .withBody(JOB_RESPONSE_DUP_TEST_DONE_WITH_ERROR))
-            .willSetStateTo("completed"));
+        stubFor(
+            post(urlPathMatching(jobsPath))
+                .inScenario("dry-run-retry")
+                .whenScenarioStateIs(Scenario.STARTED)
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(JOB_RESPONSE_DUP_TEST_DONE_WITH_ERROR)
+                )
+                .willSetStateTo("completed")
+        );
 
-        stubFor(post(urlPathMatching(jobsPath))
-            .inScenario("dry-run-retry")
-            .whenScenarioStateIs("completed")
-            .willReturn(aResponse()
-                .withStatus(200)
-                .withHeader("Content-Type", "application/json")
-                .withBody(JOB_RESPONSE_DUP_TEST_DONE)));
+        stubFor(
+            post(urlPathMatching(jobsPath))
+                .inScenario("dry-run-retry")
+                .whenScenarioStateIs("completed")
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(JOB_RESPONSE_DUP_TEST_DONE)
+                )
+        );
 
         Query task = buildDryRunQuery(wmRuntimeInfo, 3);
         RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
@@ -503,13 +657,15 @@ public class QueryErrorTest {
         Query task = Query.builder()
             .id(QueryTest.class.getSimpleName())
             .type(Query.class.getName())
-            .retryAuto(Exponential.builder()
-                .type("exponential")
-                .interval(Duration.ofMillis(100))
-                .maxInterval(Duration.ofMillis(500))
-                .maxDuration(Duration.ofSeconds(10))
-                .maxAttempts(maxAttempts)
-                .build())
+            .retryAuto(
+                Exponential.builder()
+                    .type("exponential")
+                    .interval(Duration.ofMillis(100))
+                    .maxInterval(Duration.ofMillis(500))
+                    .maxDuration(Duration.ofSeconds(10))
+                    .maxAttempts(maxAttempts)
+                    .build()
+            )
             .projectId(Property.ofValue(project))
             .sql(Property.ofValue("SELECT * from test_table"))
             .dryRun(Property.ofValue(false))
@@ -525,13 +681,15 @@ public class QueryErrorTest {
         Query task = Query.builder()
             .id(QueryTest.class.getSimpleName())
             .type(Query.class.getName())
-            .retryAuto(Exponential.builder()
-                .type("exponential")
-                .interval(Duration.ofMillis(100))
-                .maxInterval(Duration.ofMillis(500))
-                .maxDuration(Duration.ofSeconds(10))
-                .maxAttempts(maxAttempts)
-                .build())
+            .retryAuto(
+                Exponential.builder()
+                    .type("exponential")
+                    .interval(Duration.ofMillis(100))
+                    .maxInterval(Duration.ofMillis(500))
+                    .maxDuration(Duration.ofSeconds(10))
+                    .maxAttempts(maxAttempts)
+                    .build()
+            )
             .projectId(Property.ofValue(project))
             .sql(Property.ofValue("SELECT * from test_table"))
             .dryRun(Property.ofValue(true))
@@ -547,13 +705,15 @@ public class QueryErrorTest {
         Query task = Query.builder()
             .id(QueryTest.class.getSimpleName())
             .type(Query.class.getName())
-            .retryAuto(Exponential.builder()
-                .type("exponential")
-                .interval(Duration.ofMillis(100))
-                .maxInterval(Duration.ofMillis(500))
-                .maxDuration(Duration.ofSeconds(10))
-                .maxAttempts(maxAttempts)
-                .build())
+            .retryAuto(
+                Exponential.builder()
+                    .type("exponential")
+                    .interval(Duration.ofMillis(100))
+                    .maxInterval(Duration.ofMillis(500))
+                    .maxDuration(Duration.ofSeconds(10))
+                    .maxAttempts(maxAttempts)
+                    .build()
+            )
             .projectId(Property.ofValue(project))
             .sql(Property.ofValue("SELECT * from test_table"))
             .fetchType(Property.ofValue(FetchType.FETCH))

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/QueryErrorTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/QueryErrorTest.java
@@ -200,9 +200,7 @@ public class QueryErrorTest {
           }
         }""";
 
-    // BigQuery does not always answer with a structured "errors" array. A bare 5xx like this one leaves
-    // BigQueryException#getErrors() null, which used to surface as "Bigquery Errors [ - ]" with no reason
-    // to retry on, so the task failed while the job kept running to completion. See #675.
+    // A bare 5xx with no "errors" array leaves BigQueryException#getErrors() null. See #675.
     private static final String BACKEND_ERROR_RESPONSE_WITHOUT_ERROR_LIST = """
         {
           "error": {
@@ -279,6 +277,30 @@ public class QueryErrorTest {
         assertThrows(Exception.class, () -> task.run(runContext));
 
         verify(3, postRequestedFor(urlPathMatching(jobsPath)));
+    }
+
+    @Test
+    void shouldNotRetryJobCreationFailingWithoutAnErrorList(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        String jobsPath = "/bigquery/v2/projects/.*/jobs";
+
+        stubFor(
+            post(urlPathMatching(jobsPath))
+                .willReturn(
+                    aResponse()
+                        .withStatus(503)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(BACKEND_ERROR_RESPONSE_WITHOUT_ERROR_LIST)
+                )
+        );
+
+        Query task = buildQuery(wmRuntimeInfo, 3);
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        assertThrows(Exception.class, () -> task.run(runContext));
+
+        // Unlike the structured 503 above, there is no job id to re-attach to and BigQuery assigns the
+        // id itself (#674), so retrying could run the query twice. Fail once instead.
+        verify(1, postRequestedFor(urlPathMatching(jobsPath)));
     }
 
     @Test


### PR DESCRIPTION
Closes #675

## What

BigQuery only fills `BigQueryException#getErrors()` for job-level failures. Transport failures come back with that list `null`, verified against google-cloud-bigquery 2.59.0:

- `BigQueryException(int, String, Throwable)` sets `errors = null`, and `translateAndThrow` uses it for a wrapped `InterruptedException`
- `BigQueryException(IOException)` leaves `errors = null` when the response carries no structured `errors[]` payload

`AbstractBigquery#waitForJob` rethrew only that list:

```java
throw new BigQueryException(bqException.getErrors());
```

so the message, HTTP code, reason and cause were all dropped. Two consequences:

1. The user sees `Bigquery Errors [ - ]` and has nothing to diagnose.
2. `shouldRetry` only iterates the error list, so an empty list means no retry. The re-attach logic from #655 only runs at the start of a retry attempt, so it never fires. The BigQuery job completes fine and Kestra reports the task as FAILED.

This is the third report of the same failure: #493, #520, then #675. It was patched twice before, both times by null-guarding the formatting (`b385534`, `3b621d8`), which turned the NPE from #520 into an empty string without addressing the information loss.