### PR TITLE
fix(tests): bump Bigtable emulator image to 582.0.0-emulators

### DIFF
--- a/src/test/java/io/kestra/plugin/gcp/bigtable/BigtableTestUtils.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigtable/BigtableTestUtils.java
@@ -24,7 +24,9 @@ public abstract class BigtableTestUtils {
     protected static final String PROJECT_ID = "test-project";
     protected static final String INSTANCE_ID = "test-instance";
 
-    protected static final GenericContainer<?> BIGTABLE_EMULATOR = new GenericContainer<>("gcr.io/google.com/cloudsdktool/google-cloud-cli:477.0.0-emulators")
+    // gcr.io keeps only a rolling ~1 year window of google-cloud-cli tags: once this pin ages out,
+    // the image pull fails with "manifest unknown" and every Bigtable test errors on init. Bump it then.
+    protected static final GenericContainer<?> BIGTABLE_EMULATOR = new GenericContainer<>("gcr.io/google.com/cloudsdktool/google-cloud-cli:582.0.0-emulators")
         .withCommand("gcloud", "beta", "emulators", "bigtable", "start", "--host-port=0.0.0.0:8086")
         .withExposedPorts(8086);
 


### PR DESCRIPTION
## What

Bumps the Bigtable emulator container image pinned in `BigtableTestUtils` from `477.0.0-emulators` to `582.0.0-emulators`.

## Why

The nightly `Main` build went red in [run #2876](https://github.com/kestra-io/plugin-gcp/actions/runs/33468476033) with a single failure:

```
i.k.p.g.bigtable › ReadWriteRowsTest › initializationError
  Can't get Docker image: gcr.io/google.com/cloudsdktool/google-cloud-cli:477.0.0-emulators
  Caused by: Status 404: manifest unknown: Failed to fetch "477.0.0-emulators"
    at BigtableTestUtils.setUpEmulator(BigtableTestUtils.java:46)
```

This is not a code regression — run #2875 passed on the **exact same commit** (`9262ca2`) the day before. The tag was pruned upstream between the two nightlies.

Verified against the registry directly:

| tag | status |
| --- | --- |
| `477.0.0-emulators` | 404 (pruned) |
| `582.0.0-emulators` | 200 |

`gcr.io` retains only a rolling ~1 year window of `google-cloud-cli` tags — currently oldest `537.0.0-emulators` (2025-09-03), newest `582.0.0-emulators` (2026-08-25). Any hard pin will rot on roughly an annual cadence, so this adds a comment above the pin so the next `manifest unknown` failure is self-explaining.

## Testing

All 6 Bigtable tests pass locally against the new image (1m 34s, `BUILD SUCCESSFUL`):

- `createTableTask()`, `writeRowsTask()`, `writeThenReadRow()`, `triggerTask()`, `deleteRowsTask()`, `deleteTableTask()`

## Note for reviewers

Unrelated to this change: the pre-commit hook runs `spotlessApply` across the **whole project** rather than staged files only, and it reformats ~86 files on `main` (mostly import ordering). Any commit touching any Java file drags that churn into the working tree. Worth a separate cleanup commit and/or narrowing the hook — not addressed here to keep this PR to the CI fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)