### PR TITLE
docs: state connection properties per task instead of plugin defaults

### DIFF
--- a/src/main/resources/doc/io.kestra.plugin.gcp.md
+++ b/src/main/resources/doc/io.kestra.plugin.gcp.md
@@ -1,12 +1,12 @@
 # How to use the Google Cloud plugin
 
-Set the `serviceAccount` property once using plugin defaults, or let the environment provide credentials via `GOOGLE_APPLICATION_CREDENTIALS` or the default service account.
+Set the `serviceAccount` property on each task, or let the environment provide credentials via `GOOGLE_APPLICATION_CREDENTIALS` or the default service account.
 
 ## Authentication
 
 All tasks must be authenticated for the Google Cloud Platform. You can do it in multiple ways:
 
-- By setting the task `serviceAccount` property that must contain the service account JSON content. It can be handy to set this property globally by using [plugin defaults](https://kestra.io/docs/workflow-components/plugin-defaults) if your cluster accesses only one GCP project.
+- By setting the task `serviceAccount` property that must contain the service account JSON content.
 - By setting the `GOOGLE_APPLICATION_CREDENTIALS` environment variable on the nodes running Kestra. It must point to an application credentials file. Warning: it must be the same on all worker nodes and can cause some security concerns.
 - If none is set, the default service account will be used.
 
@@ -14,7 +14,7 @@ You can also set authentication scopes. By default only one scope is used: `http
 
 ## Common properties
 
-Each task allows you to configure the GCP project identifier in the `projectId` property. If not set, the default project identifier will be used (the one returned by `ServiceOptions.getDefaultProjectId()`). Set this property globally by using [plugin defaults](https://kestra.io/docs/workflow-components/plugin-defaults) if your cluster accesses only one GCP project.
+Each task allows you to configure the GCP project identifier in the `projectId` property. If not set, the default project identifier will be used (the one returned by `ServiceOptions.getDefaultProjectId()`).
 
 ## Tasks
 


### PR DESCRIPTION
Removes references to `pluginDefaults`, which was removed in the latest Kestra
release, from this plugin's documentation. Connection properties are now stated
on each task.

Part of a sweep across the plugin repositories: the docs link to
`kestra.io/docs/workflow-components/plugin-defaults` and the surrounding prose
would otherwise point users at a removed feature and a dead docs page.