### PR TITLE
fix(bigquery): never re-attach to a future-scheduled transfer run

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/bigquery/RunTransferConfig.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/RunTransferConfig.java
@@ -165,6 +165,10 @@ public class RunTransferConfig extends AbstractDataTransfer implements RunnableT
         var rWait = runContext.render(this.wait).as(Boolean.class).orElse(true);
         var rReattach = runContext.render(this.reattach).as(Boolean.class).orElse(true);
         var rReattachMaxAge = runContext.render(this.reattachMaxAge).as(Duration.class).orElse(null);
+        // A negative value pushes the staleness cutoff into the future, which would silently reject every candidate.
+        if (rReattachMaxAge != null && rReattachMaxAge.isNegative()) {
+            throw new IllegalArgumentException("`reattachMaxAge` must not be negative, got " + rReattachMaxAge);
+        }
         var rPollInterval = runContext.render(this.pollInterval).as(Duration.class).orElse(Duration.ofSeconds(15));
         var rMaxDuration = runContext.render(this.maxDuration).as(Duration.class).orElse(Duration.ofHours(1));
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/RunTransferConfig.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/RunTransferConfig.java
@@ -100,6 +100,9 @@ public class RunTransferConfig extends AbstractDataTransfer implements RunnableT
         description = """
             When `true` (default), the task first looks for a run of this config that is already \
             pending or running and adopts it, so a retried execution never starts a duplicate run. \
+            A run whose schedule time is in the future is never adopted: it is queued, not in-flight. \
+            This matters for transfers with a refresh window (Google Ads, GA4, YouTube), where Google \
+            permanently keeps a chain of pending runs queued ahead of now, one per backfill date. \
             By default any in-flight run is adopted regardless of its age; set `reattachMaxAge` to opt into \
             treating an old in-flight run as stale so a fresh run is started instead. \
             Set to `false` to always start a new run."""
@@ -238,14 +241,28 @@ public class RunTransferConfig extends AbstractDataTransfer implements RunnableT
         return output(finalRun.getName(), finalRun.getState().name(), reattached, config.getDestinationDatasetId(), rTransferConfigName);
     }
 
+    // DTS stamps scheduleTime a fraction of a second after the startManualTransferRuns call that requested
+    // the run, so a bare "now" cutoff would make a fast retry refuse to adopt the run this task just started.
+    private static final Duration REATTACH_FUTURE_GRACE = Duration.ofSeconds(30);
+
     private static TransferRun findInFlightRun(DataTransferServiceClient client, String configName, Duration reattachMaxAge, Logger logger) {
+        var now = Instant.now();
+
         // reattachMaxAge is opt-in and deliberately independent of maxDuration: maxDuration is also this
         // task's own wait budget, so using it as the staleness cutoff would make a run that is still
         // legitimately in-flight after a first attempt timed out look "stale" on the retry, causing a
         // duplicate run to be started -- defeating the whole purpose of reattach.
-        var cutoff = reattachMaxAge == null ? null : Instant.now().minus(reattachMaxAge);
+        var staleCutoff = reattachMaxAge == null ? null : now.minus(reattachMaxAge);
 
-        TransferRun mostRecent = null;
+        // A run scheduled in the future is queued, not in-flight. Transfers with a refresh window (Google
+        // Ads, GA4, YouTube) permanently keep a chain of such PENDING runs, one per backfill date, so
+        // without this bound the config always has a candidate and the task never starts a run of its own.
+        var futureCutoff = now.plus(REATTACH_FUTURE_GRACE);
+
+        TransferRun best = null;
+        Instant bestScheduleTime = null;
+        var queuedSkipped = 0;
+
         for (TransferRun candidate : client.listTransferRuns(
             ListTransferRunsRequest.newBuilder()
                 .setParent(configName)
@@ -253,21 +270,46 @@ public class RunTransferConfig extends AbstractDataTransfer implements RunnableT
                 .addStates(TransferState.RUNNING)
                 .build()
         ).iterateAll()) {
-            if (cutoff != null) {
-                var scheduleTime = Instant.ofEpochMilli(Timestamps.toMillis(candidate.getScheduleTime()));
-                if (scheduleTime.isBefore(cutoff)) {
-                    logger.info(
-                        "Ignoring in-flight transfer run '{}' scheduled at {} because it is older than reattachMaxAge ({}); a fresh run will be started",
-                        candidate.getName(), scheduleTime, reattachMaxAge
-                    );
-                    continue;
-                }
+            var scheduleTime = Instant.ofEpochMilli(Timestamps.toMillis(candidate.getScheduleTime()));
+
+            if (scheduleTime.isAfter(futureCutoff)) {
+                queuedSkipped++;
+                continue;
             }
-            if (mostRecent == null || Timestamps.compare(candidate.getScheduleTime(), mostRecent.getScheduleTime()) > 0) {
-                mostRecent = candidate;
+
+            if (staleCutoff != null && scheduleTime.isBefore(staleCutoff)) {
+                logger.info(
+                    "Ignoring in-flight transfer run '{}' scheduled at {} because it is older than reattachMaxAge ({}); a fresh run will be started",
+                    candidate.getName(), scheduleTime, reattachMaxAge
+                );
+                continue;
+            }
+
+            if (best == null || outranks(candidate, scheduleTime, best, bestScheduleTime)) {
+                best = candidate;
+                bestScheduleTime = scheduleTime;
             }
         }
-        return mostRecent;
+
+        if (queuedSkipped > 0) {
+            // Normal for a refresh-window config, so this explains rather than warns.
+            logger.info(
+                "Ignoring {} transfer run(s) of '{}' scheduled in the future -- they are queued, not in-flight",
+                queuedSkipped, configName
+            );
+        }
+
+        return best;
+    }
+
+    // A RUNNING candidate always beats a PENDING one. Within the same state the latest scheduleTime wins.
+    private static boolean outranks(TransferRun candidate, Instant candidateScheduleTime, TransferRun best, Instant bestScheduleTime) {
+        var candidateRunning = candidate.getState() == TransferState.RUNNING;
+        var bestRunning = best.getState() == TransferState.RUNNING;
+        if (candidateRunning != bestRunning) {
+            return candidateRunning;
+        }
+        return candidateScheduleTime.isAfter(bestScheduleTime);
     }
 
     private static boolean isTerminal(TransferState state) {

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/RunTransferConfig.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/RunTransferConfig.java
@@ -2,6 +2,7 @@ package io.kestra.plugin.gcp.bigquery;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Objects;
@@ -245,7 +246,12 @@ public class RunTransferConfig extends AbstractDataTransfer implements RunnableT
     // the run, so a bare "now" cutoff would make a fast retry refuse to adopt the run this task just started.
     private static final Duration REATTACH_FUTURE_GRACE = Duration.ofSeconds(30);
 
+    // A RUNNING candidate always beats a PENDING one. Within the same state the latest schedule time wins.
+    private static final Comparator<TransferRun> BY_LIVENESS = Comparator.comparing((TransferRun run) -> run.getState() == TransferState.RUNNING)
+        .thenComparing(TransferRun::getScheduleTime, Timestamps.comparator());
+
     private static TransferRun findInFlightRun(DataTransferServiceClient client, String configName, Duration reattachMaxAge, Logger logger) {
+        // Both cutoffs come from one clock read so a candidate cannot fall between them.
         var now = Instant.now();
 
         // reattachMaxAge is opt-in and deliberately independent of maxDuration: maxDuration is also this
@@ -260,8 +266,7 @@ public class RunTransferConfig extends AbstractDataTransfer implements RunnableT
         var futureCutoff = now.plus(REATTACH_FUTURE_GRACE);
 
         TransferRun best = null;
-        Instant bestScheduleTime = null;
-        var queuedSkipped = 0;
+        var queued = 0;
 
         for (TransferRun candidate : client.listTransferRuns(
             ListTransferRunsRequest.newBuilder()
@@ -273,43 +278,26 @@ public class RunTransferConfig extends AbstractDataTransfer implements RunnableT
             var scheduleTime = Instant.ofEpochMilli(Timestamps.toMillis(candidate.getScheduleTime()));
 
             if (scheduleTime.isAfter(futureCutoff)) {
-                queuedSkipped++;
-                continue;
-            }
-
-            if (staleCutoff != null && scheduleTime.isBefore(staleCutoff)) {
+                queued++;
+            } else if (staleCutoff != null && scheduleTime.isBefore(staleCutoff)) {
                 logger.info(
                     "Ignoring in-flight transfer run '{}' scheduled at {} because it is older than reattachMaxAge ({}); a fresh run will be started",
                     candidate.getName(), scheduleTime, reattachMaxAge
                 );
-                continue;
-            }
-
-            if (best == null || outranks(candidate, scheduleTime, best, bestScheduleTime)) {
+            } else if (best == null || BY_LIVENESS.compare(candidate, best) > 0) {
                 best = candidate;
-                bestScheduleTime = scheduleTime;
             }
         }
 
-        if (queuedSkipped > 0) {
+        if (queued > 0) {
             // Normal for a refresh-window config, so this explains rather than warns.
             logger.info(
                 "Ignoring {} transfer run(s) of '{}' scheduled in the future -- they are queued, not in-flight",
-                queuedSkipped, configName
+                queued, configName
             );
         }
 
         return best;
-    }
-
-    // A RUNNING candidate always beats a PENDING one. Within the same state the latest scheduleTime wins.
-    private static boolean outranks(TransferRun candidate, Instant candidateScheduleTime, TransferRun best, Instant bestScheduleTime) {
-        var candidateRunning = candidate.getState() == TransferState.RUNNING;
-        var bestRunning = best.getState() == TransferState.RUNNING;
-        if (candidateRunning != bestRunning) {
-            return candidateRunning;
-        }
-        return candidateScheduleTime.isAfter(bestScheduleTime);
     }
 
     private static boolean isTerminal(TransferState state) {

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/RunTransferConfig.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/RunTransferConfig.java
@@ -242,8 +242,7 @@ public class RunTransferConfig extends AbstractDataTransfer implements RunnableT
         return output(finalRun.getName(), finalRun.getState().name(), reattached, config.getDestinationDatasetId(), rTransferConfigName);
     }
 
-    // DTS stamps scheduleTime a fraction of a second after the startManualTransferRuns call that requested
-    // the run, so a bare "now" cutoff would make a fast retry refuse to adopt the run this task just started.
+    // Absorbs the drift between the startManualTransferRuns call and the scheduleTime DTS stamps on it.
     private static final Duration REATTACH_FUTURE_GRACE = Duration.ofSeconds(30);
 
     // A RUNNING candidate always beats a PENDING one. Within the same state the latest schedule time wins.
@@ -260,9 +259,7 @@ public class RunTransferConfig extends AbstractDataTransfer implements RunnableT
         // duplicate run to be started -- defeating the whole purpose of reattach.
         var staleCutoff = reattachMaxAge == null ? null : now.minus(reattachMaxAge);
 
-        // A run scheduled in the future is queued, not in-flight. Transfers with a refresh window (Google
-        // Ads, GA4, YouTube) permanently keep a chain of such PENDING runs, one per backfill date, so
-        // without this bound the config always has a candidate and the task never starts a run of its own.
+        // A run scheduled in the future is queued, not in-flight.
         var futureCutoff = now.plus(REATTACH_FUTURE_GRACE);
 
         TransferRun best = null;

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/RunTransferConfig.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/RunTransferConfig.java
@@ -101,7 +101,8 @@ public class RunTransferConfig extends AbstractDataTransfer implements RunnableT
         description = """
             When `true` (default), the task first looks for a run of this config that is already \
             pending or running and adopts it, so a retried execution never starts a duplicate run. \
-            A run whose schedule time is in the future is never adopted: it is queued, not in-flight. \
+            A pending run whose schedule time is in the future is never adopted: it is queued, not in-flight. \
+            A running run is always in-flight and stays eligible whatever its schedule time. \
             This matters for transfers with a refresh window (Google Ads, GA4, YouTube), where Google \
             permanently keeps a chain of pending runs queued ahead of now, one per backfill date. \
             By default any in-flight run is adopted regardless of its age; set `reattachMaxAge` to opt into \
@@ -263,7 +264,7 @@ public class RunTransferConfig extends AbstractDataTransfer implements RunnableT
         // duplicate run to be started -- defeating the whole purpose of reattach.
         var staleCutoff = reattachMaxAge == null ? null : now.minus(reattachMaxAge);
 
-        // A run scheduled in the future is queued, not in-flight.
+        // A PENDING run scheduled in the future is queued. RUNNING is in-flight whatever its schedule time.
         var futureCutoff = now.plus(REATTACH_FUTURE_GRACE);
 
         TransferRun best = null;
@@ -278,7 +279,7 @@ public class RunTransferConfig extends AbstractDataTransfer implements RunnableT
         ).iterateAll()) {
             var scheduleTime = Instant.ofEpochMilli(Timestamps.toMillis(candidate.getScheduleTime()));
 
-            if (scheduleTime.isAfter(futureCutoff)) {
+            if (candidate.getState() == TransferState.PENDING && scheduleTime.isAfter(futureCutoff)) {
                 queued++;
             } else if (staleCutoff != null && scheduleTime.isBefore(staleCutoff)) {
                 logger.info(
@@ -293,7 +294,7 @@ public class RunTransferConfig extends AbstractDataTransfer implements RunnableT
         if (queued > 0) {
             // Normal for a refresh-window config, so this explains rather than warns.
             logger.info(
-                "Ignoring {} transfer run(s) of '{}' scheduled in the future -- they are queued, not in-flight",
+                "Ignoring {} pending transfer run(s) of '{}' scheduled in the future -- they are queued, not in-flight",
                 queued, configName
             );
         }

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/RunTransferConfigWireMockTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/RunTransferConfigWireMockTest.java
@@ -53,8 +53,7 @@ class RunTransferConfigWireMockTest {
     private static final String CONFIG_NAME = "projects/my-project/locations/us/transferConfigs/615123456789012345";
     private static final String RUN_NAME = CONFIG_NAME + "/runs/run-abc123";
 
-    // Schedule times for the reattach cutoff tests must be relative to now, not literals: a literal
-    // that is in the past today silently flips to the future once wall-clock time passes it.
+    // A literal schedule time that is in the past today silently flips to the future later on.
     private static String scheduleTimeFromNow(Duration offset) {
         return Instant.now().plus(offset).toString();
     }
@@ -390,9 +389,9 @@ class RunTransferConfigWireMockTest {
     void reattachIgnoresFutureScheduledRunAndStartsNewOne(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         var queuedRunName = CONFIG_NAME + "/runs/run-queued";
         var newRunName = CONFIG_NAME + "/runs/run-fresh";
+        var newRunScheduleTime = scheduleTimeFromNow(Duration.ZERO);
 
-        // A refresh-window transfer permanently keeps runs queued ahead of now. Adopting one made the
-        // task idle until Google's own schedule reached it, then report success for a stale date slice.
+        // A refresh-window transfer permanently keeps runs queued ahead of now.
         stubFor(
             get(urlPathEqualTo("/v1/" + CONFIG_NAME + "/runs"))
                 .willReturn(
@@ -429,7 +428,7 @@ class RunTransferConfigWireMockTest {
                                 }
                               ]
                             }
-                            """.formatted(newRunName, scheduleTimeFromNow(Duration.ZERO)))
+                            """.formatted(newRunName, newRunScheduleTime))
                 )
         );
 
@@ -445,7 +444,7 @@ class RunTransferConfigWireMockTest {
                               "state": "SUCCEEDED",
                               "scheduleTime": "%s"
                             }
-                            """.formatted(newRunName, scheduleTimeFromNow(Duration.ZERO)))
+                            """.formatted(newRunName, newRunScheduleTime))
                 )
         );
 
@@ -491,9 +490,9 @@ class RunTransferConfigWireMockTest {
     @Test
     void reattachAdoptsRunScheduledWithinGrace(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         var inFlightRunName = CONFIG_NAME + "/runs/run-just-started";
+        var scheduleTime = scheduleTimeFromNow(Duration.ofSeconds(2));
 
-        // DTS stamps scheduleTime a fraction of a second after the call that requested the run, so a
-        // marginally future schedule time still belongs to a run this task started and must be adopted.
+        // A marginally future schedule time still belongs to a run this task started.
         stubFor(
             get(urlPathEqualTo("/v1/" + CONFIG_NAME + "/runs"))
                 .willReturn(
@@ -510,7 +509,7 @@ class RunTransferConfigWireMockTest {
                                 }
                               ]
                             }
-                            """.formatted(inFlightRunName, scheduleTimeFromNow(Duration.ofSeconds(2))))
+                            """.formatted(inFlightRunName, scheduleTime))
                 )
         );
 
@@ -526,7 +525,7 @@ class RunTransferConfigWireMockTest {
                               "state": "SUCCEEDED",
                               "scheduleTime": "%s"
                             }
-                            """.formatted(inFlightRunName, scheduleTimeFromNow(Duration.ofSeconds(2))))
+                            """.formatted(inFlightRunName, scheduleTime))
                 )
         );
 
@@ -572,6 +571,7 @@ class RunTransferConfigWireMockTest {
     void reattachPrefersRunningOverPending(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         var runningRunName = CONFIG_NAME + "/runs/run-running";
         var pendingRunName = CONFIG_NAME + "/runs/run-pending";
+        var runningScheduleTime = scheduleTimeFromNow(Duration.ofMinutes(-30));
 
         // The PENDING candidate has the later scheduleTime, so schedule-time-only ordering would pick it.
         stubFor(
@@ -597,7 +597,7 @@ class RunTransferConfigWireMockTest {
                                   ]
                                 }
                                 """.formatted(
-                                runningRunName, scheduleTimeFromNow(Duration.ofMinutes(-30)),
+                                runningRunName, runningScheduleTime,
                                 pendingRunName, scheduleTimeFromNow(Duration.ofMinutes(-5))
                             )
                         )
@@ -616,7 +616,7 @@ class RunTransferConfigWireMockTest {
                               "state": "SUCCEEDED",
                               "scheduleTime": "%s"
                             }
-                            """.formatted(runningRunName, scheduleTimeFromNow(Duration.ofMinutes(-30))))
+                            """.formatted(runningRunName, runningScheduleTime))
                 )
         );
 

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/RunTransferConfigWireMockTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/RunTransferConfigWireMockTest.java
@@ -568,6 +568,87 @@ class RunTransferConfigWireMockTest {
     }
 
     @Test
+    void reattachAdoptsRunningRunScheduledInTheFuture(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        var runningRunName = CONFIG_NAME + "/runs/run-running-future";
+        var scheduleTime = scheduleTimeFromNow(Duration.ofHours(1));
+
+        // RUNNING is in-flight by definition, so the future cutoff must not reach it. A worker clock
+        // lagging Google by more than the grace would otherwise drop every genuinely in-flight run.
+        stubFor(
+            get(urlPathEqualTo("/v1/" + CONFIG_NAME + "/runs"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "transferRuns": [
+                                {
+                                  "name": "%s",
+                                  "state": "RUNNING",
+                                  "scheduleTime": "%s"
+                                }
+                              ]
+                            }
+                            """.formatted(runningRunName, scheduleTime))
+                )
+        );
+
+        stubFor(
+            get(urlPathEqualTo("/v1/" + runningRunName))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "name": "%s",
+                              "state": "SUCCEEDED",
+                              "scheduleTime": "%s"
+                            }
+                            """.formatted(runningRunName, scheduleTime))
+                )
+        );
+
+        stubFor(
+            get(urlPathEqualTo("/v1/" + CONFIG_NAME))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "name": "%s",
+                              "destinationDatasetId": "my_dataset"
+                            }
+                            """.formatted(CONFIG_NAME))
+                )
+        );
+
+        var task = RunTransferConfig.builder()
+            .id(IdUtils.create())
+            .type(RunTransferConfig.class.getName())
+            .transferConfigName(Property.ofValue(CONFIG_NAME))
+            .reattach(Property.ofValue(true))
+            .wait(Property.ofValue(true))
+            .pollInterval(Property.ofValue(Duration.ofMillis(50)))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(10)))
+            .assets(new AssetsDeclaration(true, List.of(), List.of()))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        try (DataTransferServiceClient client = httpJsonClient(wmRuntimeInfo)) {
+            var output = task.run(runContext, client);
+
+            assertThat("a RUNNING run is in-flight whatever its schedule time", output.isReattached(), is(true));
+            assertThat(output.getRunName(), is(runningRunName));
+        }
+
+        verify(0, postRequestedFor(urlPathEqualTo("/v1/" + CONFIG_NAME + ":startManualRuns")));
+    }
+
+    @Test
     void reattachMaxAgeAndFutureCutoffBothApply(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
         var staleRunName = CONFIG_NAME + "/runs/run-stale";
         var queuedRunName = CONFIG_NAME + "/runs/run-queued";

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/RunTransferConfigWireMockTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/RunTransferConfigWireMockTest.java
@@ -1,6 +1,7 @@
 package io.kestra.plugin.gcp.bigquery;
 
 import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
 
@@ -51,6 +52,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class RunTransferConfigWireMockTest {
     private static final String CONFIG_NAME = "projects/my-project/locations/us/transferConfigs/615123456789012345";
     private static final String RUN_NAME = CONFIG_NAME + "/runs/run-abc123";
+
+    // Schedule times for the reattach cutoff tests must be relative to now, not literals: a literal
+    // that is in the past today silently flips to the future once wall-clock time passes it.
+    private static String scheduleTimeFromNow(Duration offset) {
+        return Instant.now().plus(offset).toString();
+    }
 
     @Inject
     private RunContextFactory runContextFactory;
@@ -377,6 +384,278 @@ class RunTransferConfigWireMockTest {
         }
 
         verify(1, postRequestedFor(urlPathEqualTo("/v1/" + CONFIG_NAME + ":startManualRuns")));
+    }
+
+    @Test
+    void reattachIgnoresFutureScheduledRunAndStartsNewOne(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        var queuedRunName = CONFIG_NAME + "/runs/run-queued";
+        var newRunName = CONFIG_NAME + "/runs/run-fresh";
+
+        // A refresh-window transfer permanently keeps runs queued ahead of now. Adopting one made the
+        // task idle until Google's own schedule reached it, then report success for a stale date slice.
+        stubFor(
+            get(urlPathEqualTo("/v1/" + CONFIG_NAME + "/runs"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "transferRuns": [
+                                {
+                                  "name": "%s",
+                                  "state": "PENDING",
+                                  "scheduleTime": "%s"
+                                }
+                              ]
+                            }
+                            """.formatted(queuedRunName, scheduleTimeFromNow(Duration.ofHours(1))))
+                )
+        );
+
+        stubFor(
+            post(urlPathEqualTo("/v1/" + CONFIG_NAME + ":startManualRuns"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "runs": [
+                                {
+                                  "name": "%s",
+                                  "state": "PENDING",
+                                  "scheduleTime": "%s"
+                                }
+                              ]
+                            }
+                            """.formatted(newRunName, scheduleTimeFromNow(Duration.ZERO)))
+                )
+        );
+
+        stubFor(
+            get(urlPathEqualTo("/v1/" + newRunName))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "name": "%s",
+                              "state": "SUCCEEDED",
+                              "scheduleTime": "%s"
+                            }
+                            """.formatted(newRunName, scheduleTimeFromNow(Duration.ZERO)))
+                )
+        );
+
+        stubFor(
+            get(urlPathEqualTo("/v1/" + CONFIG_NAME))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "name": "%s",
+                              "destinationDatasetId": "my_dataset"
+                            }
+                            """.formatted(CONFIG_NAME))
+                )
+        );
+
+        var task = RunTransferConfig.builder()
+            .id(IdUtils.create())
+            .type(RunTransferConfig.class.getName())
+            .transferConfigName(Property.ofValue(CONFIG_NAME))
+            .reattach(Property.ofValue(true))
+            .wait(Property.ofValue(true))
+            .pollInterval(Property.ofValue(Duration.ofMillis(50)))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(10)))
+            .assets(new AssetsDeclaration(true, List.of(), List.of()))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        try (DataTransferServiceClient client = httpJsonClient(wmRuntimeInfo)) {
+            var output = task.run(runContext, client);
+
+            assertThat("a run scheduled in the future is queued, not in-flight, so it must not be adopted", output.isReattached(), is(false));
+            assertThat(output.getRunName(), is(newRunName));
+            assertThat(output.getState(), is("SUCCEEDED"));
+        }
+
+        verify(1, postRequestedFor(urlPathEqualTo("/v1/" + CONFIG_NAME + ":startManualRuns")));
+    }
+
+    @Test
+    void reattachAdoptsRunScheduledWithinGrace(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        var inFlightRunName = CONFIG_NAME + "/runs/run-just-started";
+
+        // DTS stamps scheduleTime a fraction of a second after the call that requested the run, so a
+        // marginally future schedule time still belongs to a run this task started and must be adopted.
+        stubFor(
+            get(urlPathEqualTo("/v1/" + CONFIG_NAME + "/runs"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "transferRuns": [
+                                {
+                                  "name": "%s",
+                                  "state": "PENDING",
+                                  "scheduleTime": "%s"
+                                }
+                              ]
+                            }
+                            """.formatted(inFlightRunName, scheduleTimeFromNow(Duration.ofSeconds(2))))
+                )
+        );
+
+        stubFor(
+            get(urlPathEqualTo("/v1/" + inFlightRunName))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "name": "%s",
+                              "state": "SUCCEEDED",
+                              "scheduleTime": "%s"
+                            }
+                            """.formatted(inFlightRunName, scheduleTimeFromNow(Duration.ofSeconds(2))))
+                )
+        );
+
+        stubFor(
+            get(urlPathEqualTo("/v1/" + CONFIG_NAME))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "name": "%s",
+                              "destinationDatasetId": "my_dataset"
+                            }
+                            """.formatted(CONFIG_NAME))
+                )
+        );
+
+        var task = RunTransferConfig.builder()
+            .id(IdUtils.create())
+            .type(RunTransferConfig.class.getName())
+            .transferConfigName(Property.ofValue(CONFIG_NAME))
+            .reattach(Property.ofValue(true))
+            .wait(Property.ofValue(true))
+            .pollInterval(Property.ofValue(Duration.ofMillis(50)))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(10)))
+            .assets(new AssetsDeclaration(true, List.of(), List.of()))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        try (DataTransferServiceClient client = httpJsonClient(wmRuntimeInfo)) {
+            var output = task.run(runContext, client);
+
+            assertThat("a run scheduled just ahead of now is the task's own run and must still be adopted", output.isReattached(), is(true));
+            assertThat(output.getRunName(), is(inFlightRunName));
+        }
+
+        verify(0, postRequestedFor(urlPathEqualTo("/v1/" + CONFIG_NAME + ":startManualRuns")));
+    }
+
+    @Test
+    void reattachPrefersRunningOverPending(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        var runningRunName = CONFIG_NAME + "/runs/run-running";
+        var pendingRunName = CONFIG_NAME + "/runs/run-pending";
+
+        // The PENDING candidate has the later scheduleTime, so schedule-time-only ordering would pick it.
+        stubFor(
+            get(urlPathEqualTo("/v1/" + CONFIG_NAME + "/runs"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(
+                            """
+                                {
+                                  "transferRuns": [
+                                    {
+                                      "name": "%s",
+                                      "state": "RUNNING",
+                                      "scheduleTime": "%s"
+                                    },
+                                    {
+                                      "name": "%s",
+                                      "state": "PENDING",
+                                      "scheduleTime": "%s"
+                                    }
+                                  ]
+                                }
+                                """.formatted(
+                                runningRunName, scheduleTimeFromNow(Duration.ofMinutes(-30)),
+                                pendingRunName, scheduleTimeFromNow(Duration.ofMinutes(-5))
+                            )
+                        )
+                )
+        );
+
+        stubFor(
+            get(urlPathEqualTo("/v1/" + runningRunName))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "name": "%s",
+                              "state": "SUCCEEDED",
+                              "scheduleTime": "%s"
+                            }
+                            """.formatted(runningRunName, scheduleTimeFromNow(Duration.ofMinutes(-30))))
+                )
+        );
+
+        stubFor(
+            get(urlPathEqualTo("/v1/" + CONFIG_NAME))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "name": "%s",
+                              "destinationDatasetId": "my_dataset"
+                            }
+                            """.formatted(CONFIG_NAME))
+                )
+        );
+
+        var task = RunTransferConfig.builder()
+            .id(IdUtils.create())
+            .type(RunTransferConfig.class.getName())
+            .transferConfigName(Property.ofValue(CONFIG_NAME))
+            .reattach(Property.ofValue(true))
+            .wait(Property.ofValue(true))
+            .pollInterval(Property.ofValue(Duration.ofMillis(50)))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(10)))
+            .assets(new AssetsDeclaration(true, List.of(), List.of()))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        try (DataTransferServiceClient client = httpJsonClient(wmRuntimeInfo)) {
+            var output = task.run(runContext, client);
+
+            assertThat(output.isReattached(), is(true));
+            assertThat("a RUNNING candidate must outrank a PENDING one with a later schedule time", output.getRunName(), is(runningRunName));
+        }
+
+        verify(0, postRequestedFor(urlPathEqualTo("/v1/" + CONFIG_NAME + ":startManualRuns")));
     }
 
     @Test

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/RunTransferConfigWireMockTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/RunTransferConfigWireMockTest.java
@@ -53,7 +53,7 @@ class RunTransferConfigWireMockTest {
     private static final String CONFIG_NAME = "projects/my-project/locations/us/transferConfigs/615123456789012345";
     private static final String RUN_NAME = CONFIG_NAME + "/runs/run-abc123";
 
-    // A literal schedule time that is in the past today silently flips to the future later on.
+    // A literal schedule time picked as future at write time silently becomes past, flipping which branch runs.
     private static String scheduleTimeFromNow(Duration offset) {
         return Instant.now().plus(offset).toString();
     }
@@ -562,6 +562,141 @@ class RunTransferConfigWireMockTest {
 
             assertThat("a run scheduled just ahead of now is the task's own run and must still be adopted", output.isReattached(), is(true));
             assertThat(output.getRunName(), is(inFlightRunName));
+        }
+
+        verify(0, postRequestedFor(urlPathEqualTo("/v1/" + CONFIG_NAME + ":startManualRuns")));
+    }
+
+    @Test
+    void reattachMaxAgeAndFutureCutoffBothApply(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        var staleRunName = CONFIG_NAME + "/runs/run-stale";
+        var queuedRunName = CONFIG_NAME + "/runs/run-queued";
+        var newRunName = CONFIG_NAME + "/runs/run-fresh";
+        var newRunScheduleTime = scheduleTimeFromNow(Duration.ZERO);
+
+        // One candidate fails each bound, so neither cutoff can rescue a candidate the other rejects.
+        stubFor(
+            get(urlPathEqualTo("/v1/" + CONFIG_NAME + "/runs"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(
+                            """
+                                {
+                                  "transferRuns": [
+                                    {
+                                      "name": "%s",
+                                      "state": "RUNNING",
+                                      "scheduleTime": "%s"
+                                    },
+                                    {
+                                      "name": "%s",
+                                      "state": "PENDING",
+                                      "scheduleTime": "%s"
+                                    }
+                                  ]
+                                }
+                                """.formatted(
+                                staleRunName, scheduleTimeFromNow(Duration.ofHours(-6)),
+                                queuedRunName, scheduleTimeFromNow(Duration.ofHours(1))
+                            )
+                        )
+                )
+        );
+
+        stubFor(
+            post(urlPathEqualTo("/v1/" + CONFIG_NAME + ":startManualRuns"))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "runs": [
+                                {
+                                  "name": "%s",
+                                  "state": "PENDING",
+                                  "scheduleTime": "%s"
+                                }
+                              ]
+                            }
+                            """.formatted(newRunName, newRunScheduleTime))
+                )
+        );
+
+        stubFor(
+            get(urlPathEqualTo("/v1/" + newRunName))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "name": "%s",
+                              "state": "SUCCEEDED",
+                              "scheduleTime": "%s"
+                            }
+                            """.formatted(newRunName, newRunScheduleTime))
+                )
+        );
+
+        stubFor(
+            get(urlPathEqualTo("/v1/" + CONFIG_NAME))
+                .willReturn(
+                    aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                            {
+                              "name": "%s",
+                              "destinationDatasetId": "my_dataset"
+                            }
+                            """.formatted(CONFIG_NAME))
+                )
+        );
+
+        var task = RunTransferConfig.builder()
+            .id(IdUtils.create())
+            .type(RunTransferConfig.class.getName())
+            .transferConfigName(Property.ofValue(CONFIG_NAME))
+            .reattach(Property.ofValue(true))
+            .reattachMaxAge(Property.ofValue(Duration.ofMinutes(30)))
+            .wait(Property.ofValue(true))
+            .pollInterval(Property.ofValue(Duration.ofMillis(50)))
+            .maxDuration(Property.ofValue(Duration.ofSeconds(10)))
+            .assets(new AssetsDeclaration(true, List.of(), List.of()))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        try (DataTransferServiceClient client = httpJsonClient(wmRuntimeInfo)) {
+            var output = task.run(runContext, client);
+
+            assertThat("a stale candidate and a queued candidate leave nothing to adopt", output.isReattached(), is(false));
+            assertThat(output.getRunName(), is(newRunName));
+        }
+
+        verify(1, postRequestedFor(urlPathEqualTo("/v1/" + CONFIG_NAME + ":startManualRuns")));
+    }
+
+    @Test
+    void negativeReattachMaxAgeThrows(WireMockRuntimeInfo wmRuntimeInfo) throws Exception {
+        var task = RunTransferConfig.builder()
+            .id(IdUtils.create())
+            .type(RunTransferConfig.class.getName())
+            .transferConfigName(Property.ofValue(CONFIG_NAME))
+            .reattach(Property.ofValue(true))
+            .reattachMaxAge(Property.ofValue(Duration.ofHours(-1)))
+            .assets(new AssetsDeclaration(true, List.of(), List.of()))
+            .build();
+
+        RunContext runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        try (DataTransferServiceClient client = httpJsonClient(wmRuntimeInfo)) {
+            var exception = assertThrows(IllegalArgumentException.class, () -> task.run(runContext, client));
+
+            assertThat(exception.getMessage(), containsString("`reattachMaxAge` must not be negative"));
         }
 
         verify(0, postRequestedFor(urlPathEqualTo("/v1/" + CONFIG_NAME + ":startManualRuns")));


### PR DESCRIPTION
Closes #686

`findInFlightRun` kept the candidate with the greatest `scheduleTime` and had no upper bound on it, so a run scheduled in the future always won. `reattachMaxAge` only trims candidates that are too old.

Transfers with a refresh window (Google Ads, GA4, YouTube) permanently keep a chain of `PENDING` runs queued ahead of now, one per backfill date. The config therefore always had a candidate, so the task adopted one on every execution and never started its own. Reported effect: the task idled ~85 minutes, then reported success for a run that loaded a 7-day-old date slice.

## Changes

- Skip a candidate whose `scheduleTime` is beyond now **only while it is still `PENDING`**. A run DTS reports as `RUNNING` is in-flight whatever its schedule time, and gating on state avoids dropping every in-flight run when a worker's clock lags Google by more than the grace. Thanks @jymaire.
- Prefer a `RUNNING` candidate over a `PENDING` one, falling back to latest `scheduleTime` within a state.
- Reject a negative `reattachMaxAge`. It pushed the staleness cutoff ahead of the future cutoff, so every candidate failed the freshness test and reattach silently never fired.
- Parse `scheduleTime` once per candidate, and derive both cutoffs from one `Instant.now()` read.
- One `INFO` line when queued runs are skipped. A count, not one line per run, since a refresh-window config can queue many.

## Why the cutoff is `now + 30s` and not `now`

The issue suggests a strict `scheduleTime > now` skip. Its own evidence argues for a tolerance: `run 6aac5a25` was requested at `03:01:37.7` and came back with `scheduleTime 03:01:37.862Z`, so DTS stamps a run slightly ahead of the call that created it. Under a strict comparison a fast retry would refuse to adopt the run the task itself just started and would start a duplicate, which is the failure `reattach` exists to prevent.

30s is ~200x the observed drift and ~70x below the 35-minute spacing of refresh-window runs. Kept as a private constant rather than a property: it is a clock-drift tolerance, not something a user should have to reason about.

## Tests

Six added to `RunTransferConfigWireMockTest`, 14 pass in the suite.

- `reattachIgnoresFutureScheduledRunAndStartsNewOne` covers the reported scenario.
- `reattachAdoptsRunningRunScheduledInTheFuture` locks in that the cutoff never reaches a `RUNNING` run.
- `reattachPrefersRunningOverPending` gives the `PENDING` candidate the later `scheduleTime`, so schedule-time-only ordering picks the wrong run.
- `reattachAdoptsRunScheduledWithinGrace` guards the drift case against over-correction.
- `reattachMaxAgeAndFutureCutoffBothApply` covers the two bounds interacting.
- `negativeReattachMaxAgeThrows` covers the guard.

Verified the behavioral ones are not vacuous: each fails with its corresponding change reverted.

The new tests build `scheduleTime` from `Instant.now()` rather than using literals. The existing stubs hardcode dates like `2026-01-01T00:00:00Z`, correct today but silently inverting once wall-clock time crosses them. Left alone here.

## Follow-up, not in this PR

`TransferRun` has a `schedule` field, documented as empty for manually-started runs and populated for runs the config's schedule created. Filtering on it would identify the task's own runs deterministically and remove the time heuristic. Not done here because it is a policy change rather than a drop-in: it would refuse to adopt the config's own scheduled run while that run is `RUNNING`, firing a second concurrent load, and a console backfill via `requestedTimeRange` creates many manual runs at once, which reintroduces the same shape through another door.

## Note for release notes

This changes the behavior of an existing default. Users on `reattach: true` with a refresh-window transfer will see `reattached` go from `true` to `false` and the task start its own run.