### PR TITLE
fix(bigquery): derive the job id from the taskrun so a resubmit cannot run it twice

### DIFF
--- a/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/AbstractBigquery.java
@@ -242,7 +242,11 @@ abstract public class AbstractBigquery extends AbstractTask implements WorkerJob
                     lastJobId.set(job.getJobId());
                     this.trackJob(connection, job.getJobId(), logger);
 
-                    BigQueryService.handleErrors(job, logger);
+                    // A submission can come back as a bare job reference. There is nothing to report yet,
+                    // and the check below runs once the state is known, so nothing is skipped for good.
+                    if (job.getStatus() != null) {
+                        BigQueryService.handleErrors(job, logger);
+                    }
 
                     logger.debug("Starting job '{}'", job.getJobId());
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryService.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryService.java
@@ -1,5 +1,6 @@
 package io.kestra.plugin.gcp.bigquery;
 
+import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -8,10 +9,13 @@ import java.util.Objects;
 
 import org.slf4j.Logger;
 
+import com.google.cloud.bigquery.BigQuery;
 import com.google.cloud.bigquery.BigQueryError;
 import com.google.cloud.bigquery.Job;
 import com.google.cloud.bigquery.JobException;
 import com.google.cloud.bigquery.JobId;
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.JobStatus;
 import com.google.cloud.bigquery.TableId;
 
 import io.kestra.core.exceptions.IllegalVariableEvaluationException;
@@ -20,11 +24,59 @@ import io.kestra.core.runners.RunContext;
 public class BigQueryService {
     private static final String UNKNOWN_REASON = "unknown";
 
+    // BigQuery reserves a caller-supplied job id, so deriving it from the taskrun makes a worker-loss
+    // resubmit collide with the job the lost worker started instead of running the same work twice.
     public static JobId jobId(RunContext runContext, AbstractBigquery abstractBigquery) throws IllegalVariableEvaluationException {
+        var taskRun = runContext.taskRunInfo();
+
         return JobId.newBuilder()
             .setProject(runContext.render(abstractBigquery.getProjectId()).as(String.class).orElse(null))
             .setLocation(runContext.render(abstractBigquery.getLocation()).as(String.class).orElse(null))
+            .setJob("kestra_" + taskRun.executionId() + "_" + taskRun.taskRunId())
             .build();
+    }
+
+    // Same project and location with no job id, so BigQuery assigns a random one as it did before.
+    private static JobId randomJobId(JobId jobId) {
+        return JobId.newBuilder()
+            .setProject(jobId.getProject())
+            .setLocation(jobId.getLocation())
+            .build();
+    }
+
+    /**
+     * Submits the job, adopting the existing one when its deterministic id is already taken. A job that
+     * already failed has burnt its id for good, so that case falls back to a fresh random id and lets the
+     * retry make progress rather than re-reporting the old failure.
+     */
+    public static Job createOrAdoptJob(BigQuery connection, JobInfo jobInfo, Logger logger) {
+        try {
+            return connection.create(jobInfo);
+        } catch (com.google.cloud.bigquery.BigQueryException e) {
+            if (e.getCode() != HttpURLConnection.HTTP_CONFLICT) {
+                throw e;
+            }
+
+            var existing = connection.getJob(jobInfo.getJobId());
+            if (existing == null) {
+                throw e;
+            }
+
+            var status = existing.getStatus();
+            if (status != null && status.getState() == JobStatus.State.DONE && status.getError() != null) {
+                logger.info("Job '{}' already ran and failed, starting a new one", jobInfo.getJobId().getJob());
+
+                return connection.create(
+                    JobInfo.newBuilder(jobInfo.getConfiguration())
+                        .setJobId(randomJobId(jobInfo.getJobId()))
+                        .build()
+                );
+            }
+
+            logger.info("Adopting job '{}' already started by this taskrun instead of submitting a duplicate", jobInfo.getJobId().getJob());
+
+            return existing;
+        }
     }
 
     public static TableId tableId(String table) {

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryService.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryService.java
@@ -27,13 +27,18 @@ public class BigQueryService {
     // BigQuery reserves a caller-supplied job id, so deriving it from the taskrun makes a worker-loss
     // resubmit collide with the job the lost worker started instead of running the same work twice.
     public static JobId jobId(RunContext runContext, AbstractBigquery abstractBigquery) throws IllegalVariableEvaluationException {
-        var taskRun = runContext.taskRunInfo();
-
-        return JobId.newBuilder()
+        var builder = JobId.newBuilder()
             .setProject(runContext.render(abstractBigquery.getProjectId()).as(String.class).orElse(null))
-            .setLocation(runContext.render(abstractBigquery.getLocation()).as(String.class).orElse(null))
-            .setJob("kestra_" + taskRun.executionId() + "_" + taskRun.taskRunId())
-            .build();
+            .setLocation(runContext.render(abstractBigquery.getLocation()).as(String.class).orElse(null));
+
+        // A trigger evaluates outside any execution, so there is no taskrun to key on and no resubmit to
+        // deduplicate. Deriving an id there would give every poll of every trigger the same one.
+        var taskRunId = runContext.taskRunInfo().taskRunId();
+        if (taskRunId != null) {
+            builder.setJob("kestra_" + taskRunId);
+        }
+
+        return builder.build();
     }
 
     // Same project and location with no job id, so BigQuery assigns a random one as it did before.
@@ -53,7 +58,8 @@ public class BigQueryService {
         try {
             return connection.create(jobInfo);
         } catch (com.google.cloud.bigquery.BigQueryException e) {
-            if (e.getCode() != HttpURLConnection.HTTP_CONFLICT) {
+            // Without a job id of our own the conflict cannot be about a job this taskrun submitted.
+            if (e.getCode() != HttpURLConnection.HTTP_CONFLICT || jobInfo.getJobId().getJob() == null) {
                 throw e;
             }
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryService.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryService.java
@@ -63,6 +63,8 @@ public class BigQueryService {
                 throw e;
             }
 
+            // BigQuery says the id is taken but will not hand the job over, so there is nothing to adopt
+            // and nothing safe to resubmit under. Failing here duplicates no work, which is the point.
             var existing = connection.getJob(jobInfo.getJobId());
             if (existing == null) {
                 throw e;
@@ -70,7 +72,7 @@ public class BigQueryService {
 
             var status = existing.getStatus();
             if (status != null && status.getState() == JobStatus.State.DONE && status.getError() != null) {
-                logger.info("Job '{}' already ran and failed, starting a new one", jobInfo.getJobId().getJob());
+                logger.warn("Job '{}' already ran and failed, starting a new one", jobInfo.getJobId().getJob());
 
                 return connection.create(
                     JobInfo.newBuilder(jobInfo.getConfiguration())
@@ -79,7 +81,7 @@ public class BigQueryService {
                 );
             }
 
-            logger.info("Adopting job '{}' already started by this taskrun instead of submitting a duplicate", jobInfo.getJobId().getJob());
+            logger.warn("Adopting job '{}' already started by this taskrun instead of submitting a duplicate", jobInfo.getJobId().getJob());
 
             return existing;
         }
@@ -100,9 +102,7 @@ public class BigQueryService {
         if (job == null) {
             throw new IllegalArgumentException("Job no longer exists");
         } else if (job.getStatus() == null) {
-            // A submission answered with a job reference and no status yet has nothing to report. The
-            // waitFor that follows establishes the real state, so a failure cannot slip through here.
-            return;
+            throw new IllegalStateException("Job '" + job.getJobId().getJob() + "' has no status to report");
         } else if (job.getStatus().getError() != null) {
             ArrayList<BigQueryError> errors = new ArrayList<>();
             if (job.getStatus().getError() != null) {

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryService.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/BigQueryService.java
@@ -99,6 +99,10 @@ public class BigQueryService {
     public static void handleErrors(Job job, Logger logger) throws BigQueryException {
         if (job == null) {
             throw new IllegalArgumentException("Job no longer exists");
+        } else if (job.getStatus() == null) {
+            // A submission answered with a job reference and no status yet has nothing to report. The
+            // waitFor that follows establishes the real state, so a failure cannot slip through here.
+            return;
         } else if (job.getStatus().getError() != null) {
             ArrayList<BigQueryError> errors = new ArrayList<>();
             if (job.getStatus().getError() != null) {

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Copy.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Copy.java
@@ -14,6 +14,7 @@ import io.kestra.core.exceptions.IllegalVariableEvaluationException;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.executions.metrics.Timer;
 import io.kestra.core.models.property.Property;
@@ -24,7 +25,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -56,7 +56,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 )
 @Schema(
     title = "Copy or snapshot BigQuery tables",
-    description = "Runs a table copy job between tables or partitions. Supports COPY, SNAPSHOT, RESTORE, or CLONE operations and honors create/write dispositions."
+    description = "Runs a table copy job between tables or partitions. Supports COPY, SNAPSHOT, RESTORE, or CLONE operations and honors create/write dispositions. The job id is derived from the taskrun, so a worker-loss resubmit adopts the job the lost worker started instead of running it twice."
 )
 public class Copy extends AbstractJob implements RunnableTask<Copy.Output> {
     @Schema(
@@ -93,12 +93,13 @@ public class Copy extends AbstractJob implements RunnableTask<Copy.Output> {
 
         Job copyJob = this.waitForJob(
             logger,
-            () -> connection
-                .create(
-                    JobInfo.newBuilder(jobConfiguration)
-                        .setJobId(BigQueryService.jobId(runContext, this))
-                        .build()
-                ),
+            () -> BigQueryService.createOrAdoptJob(
+                connection,
+                JobInfo.newBuilder(jobConfiguration)
+                    .setJobId(BigQueryService.jobId(runContext, this))
+                    .build(),
+                logger
+            ),
             runContext.render(this.dryRun).as(Boolean.class).orElseThrow(),
             runContext,
             connection

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/ExtractToGcs.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/ExtractToGcs.java
@@ -58,7 +58,7 @@ import lombok.experimental.SuperBuilder;
 )
 @Schema(
     title = "Export BigQuery table to GCS",
-    description = "Runs an extract job from a table or partition to one or more GCS URIs. Supports CSV/JSON/AVRO, optional compression, custom delimiter, and AVRO logical types. Prints a header row by default."
+    description = "Runs an extract job from a table or partition to one or more GCS URIs. Supports CSV/JSON/AVRO, optional compression, custom delimiter, and AVRO logical types. Prints a header row by default. The job id is derived from the taskrun, so a worker-loss resubmit adopts the job the lost worker started instead of running it twice."
 )
 public class ExtractToGcs extends AbstractBigquery implements RunnableTask<ExtractToGcs.Output> {
 
@@ -137,7 +137,13 @@ public class ExtractToGcs extends AbstractBigquery implements RunnableTask<Extra
         // failures, and re-attaches to the submitted job instead of extracting twice.
         Job extractJob = this.waitForJob(
             logger,
-            () -> connection.create(JobInfo.of(configuration)),
+            () -> BigQueryService.createOrAdoptJob(
+                connection,
+                JobInfo.newBuilder(configuration)
+                    .setJobId(BigQueryService.jobId(runContext, this))
+                    .build(),
+                logger
+            ),
             runContext,
             connection
         );

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/LoadFromGcs.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/LoadFromGcs.java
@@ -12,6 +12,7 @@ import com.google.cloud.bigquery.LoadJobConfiguration;
 import io.kestra.core.models.annotations.Example;
 import io.kestra.core.models.annotations.Metric;
 import io.kestra.core.models.annotations.Plugin;
+import io.kestra.core.models.annotations.PluginProperty;
 import io.kestra.core.models.executions.metrics.Counter;
 import io.kestra.core.models.executions.metrics.Timer;
 import io.kestra.core.models.property.Property;
@@ -25,7 +26,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
-import io.kestra.core.models.annotations.PluginProperty;
 
 @SuperBuilder
 @ToString
@@ -126,7 +126,7 @@ import io.kestra.core.models.annotations.PluginProperty;
 )
 @Schema(
     title = "Load GCS objects into BigQuery",
-    description = "Runs a BigQuery load job from one or more GCS URIs into the destination table. Supports wildcard paths, format-specific options, and standard load limits. Table must exist unless schema is supplied with a write disposition that creates it."
+    description = "Runs a BigQuery load job from one or more GCS URIs into the destination table. Supports wildcard paths, format-specific options, and standard load limits. Table must exist unless schema is supplied with a write disposition that creates it. The job id is derived from the taskrun, so a worker-loss resubmit adopts the job the lost worker started instead of running it twice."
 )
 public class LoadFromGcs extends AbstractLoad implements RunnableTask<AbstractLoad.Output> {
     @Schema(
@@ -154,10 +154,12 @@ public class LoadFromGcs extends AbstractLoad implements RunnableTask<AbstractLo
         logger.debug("Starting query\n{}", JacksonMapper.log(configuration));
 
         Job loadJob = this.waitForJob(
-            logger, () -> connection.create(
+            logger, () -> BigQueryService.createOrAdoptJob(
+                connection,
                 JobInfo.newBuilder(configuration)
                     .setJobId(BigQueryService.jobId(runContext, this))
-                    .build()
+                    .build(),
+                logger
             ), runContext, connection
         );
 

--- a/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
+++ b/src/main/java/io/kestra/plugin/gcp/bigquery/Query.java
@@ -123,7 +123,7 @@ import reactor.core.publisher.Mono;
 )
 @Schema(
     title = "Execute a BigQuery SQL job",
-    description = "Runs a SQL statement with standard SQL by default, optionally writing into a destination table. Supports cache usage, priority selection, schema updates, and deprecated fetch/store outputs (superseded by `fetchType`). Uses task-level project, service account, and scopes."
+    description = "Runs a SQL statement with standard SQL by default, optionally writing into a destination table. Supports cache usage, priority selection, schema updates, and deprecated fetch/store outputs (superseded by `fetchType`). Uses task-level project, service account, and scopes. The job id is derived from the taskrun, so a worker-loss resubmit adopts the job the lost worker started instead of running it twice."
 )
 @StoreFetchValidation
 @StoreFetchDestinationValidation
@@ -304,12 +304,13 @@ public class Query extends AbstractJob implements RunnableTask<Query.Output>, Qu
 
         Job queryJob = this.waitForJob(
             logger,
-            () -> connection
-                .create(
-                    JobInfo.newBuilder(jobConfiguration)
-                        .setJobId(BigQueryService.jobId(runContext, this))
-                        .build()
-                ),
+            () -> BigQueryService.createOrAdoptJob(
+                connection,
+                JobInfo.newBuilder(jobConfiguration)
+                    .setJobId(BigQueryService.jobId(runContext, this))
+                    .build(),
+                logger
+            ),
             runContext.render(this.dryRun).as(Boolean.class).orElseThrow(),
             runContext,
             connection

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/BigQueryJobIdTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/BigQueryJobIdTest.java
@@ -1,0 +1,191 @@
+package io.kestra.plugin.gcp.bigquery;
+
+import java.net.HttpURLConnection;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.google.cloud.bigquery.BigQuery;
+import com.google.cloud.bigquery.BigQueryError;
+import com.google.cloud.bigquery.Job;
+import com.google.cloud.bigquery.JobId;
+import com.google.cloud.bigquery.JobInfo;
+import com.google.cloud.bigquery.JobStatus;
+import com.google.cloud.bigquery.QueryJobConfiguration;
+import com.google.common.collect.ImmutableMap;
+
+import io.kestra.core.junit.annotations.KestraTest;
+import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContextFactory;
+import io.kestra.core.utils.TestsUtils;
+
+import jakarta.inject.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * A random job id let a worker-loss resubmit start a second job doing the same work.
+ *
+ * @see <a href="https://github.com/kestra-io/plugin-gcp/issues/674">#674</a>
+ */
+@KestraTest
+class BigQueryJobIdTest {
+    private static final QueryJobConfiguration CONFIGURATION = QueryJobConfiguration.newBuilder("SELECT 1").build();
+
+    @Inject
+    private RunContextFactory runContextFactory;
+
+    @Test
+    void shouldDeriveTheJobIdFromTheTaskrun() throws Exception {
+        var task = task();
+        var runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        var jobId = BigQueryService.jobId(runContext, task);
+
+        assertThat(jobId.getJob(), notNullValue());
+        assertThat(jobId.getJob(), startsWith("kestra_"));
+        assertThat(jobId.getJob(), is("kestra_" + runContext.taskRunInfo().executionId() + "_" + runContext.taskRunInfo().taskRunId()));
+    }
+
+    @Test
+    void shouldGiveTheSameJobIdToEveryAttemptOfATaskrun() throws Exception {
+        var task = task();
+        var runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        // The whole point: a resubmit on another worker must land on the id the lost worker used.
+        // Compare the job segment, not the whole JobId: two absent ids also compare equal.
+        var first = BigQueryService.jobId(runContext, task).getJob();
+        var second = BigQueryService.jobId(runContext, task).getJob();
+
+        assertThat(first, notNullValue());
+        assertThat(second, is(first));
+    }
+
+    @Test
+    void shouldGiveDifferentJobIdsToDifferentTaskruns() throws Exception {
+        var task = task();
+        var first = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+        var second = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+
+        assertThat(BigQueryService.jobId(first, task).getJob(), not(BigQueryService.jobId(second, task).getJob()));
+    }
+
+    @Test
+    void shouldAdoptTheRunningJobWhenTheIdIsAlreadyTaken() {
+        var connection = Mockito.mock(BigQuery.class);
+        var jobInfo = jobInfo("kestra_exec_taskrun");
+        var running = job(null);
+
+        Mockito.when(connection.create(jobInfo)).thenThrow(conflict());
+        Mockito.when(connection.getJob(jobInfo.getJobId())).thenReturn(running);
+
+        var adopted = BigQueryService.createOrAdoptJob(connection, jobInfo, logger());
+
+        assertThat("the job the lost worker started must be adopted, not duplicated", adopted, is(running));
+        Mockito.verify(connection, Mockito.times(1)).create(Mockito.any(JobInfo.class));
+    }
+
+    @Test
+    void shouldStartAFreshJobWhenTheTakenIdBelongsToAFailedJob() {
+        var connection = Mockito.mock(BigQuery.class);
+        var jobInfo = jobInfo("kestra_exec_taskrun");
+        var replacement = job(null);
+        var failed = job(new BigQueryError("invalidQuery", null, "Syntax error"));
+        var submitted = new AtomicReference<JobInfo>();
+
+        // BigQuery reserves the id for good, so a retry can only make progress with a new one.
+        Mockito.when(connection.create(jobInfo)).thenThrow(conflict());
+        Mockito.when(connection.getJob(jobInfo.getJobId())).thenReturn(failed);
+        Mockito.when(connection.create(Mockito.<JobInfo> argThat(info -> info != null && !jobInfo.equals(info))))
+            .thenAnswer(invocation ->
+            {
+                submitted.set(invocation.getArgument(0));
+                return replacement;
+            });
+
+        var created = BigQueryService.createOrAdoptJob(connection, jobInfo, logger());
+
+        assertThat(created, is(replacement));
+        assertThat("a burnt id must be replaced by one BigQuery assigns", submitted.get().getJobId().getJob(), nullValue());
+        assertThat(submitted.get().getJobId().getProject(), is("my-project"));
+        assertThat(submitted.get().getJobId().getLocation(), is("EU"));
+    }
+
+    @Test
+    void shouldRethrowAConflictWhenTheJobCannotBeFetched() {
+        var connection = Mockito.mock(BigQuery.class);
+        var jobInfo = jobInfo("kestra_exec_taskrun");
+
+        Mockito.when(connection.create(jobInfo)).thenThrow(conflict());
+        Mockito.when(connection.getJob(jobInfo.getJobId())).thenReturn(null);
+
+        var thrown = assertThrows(
+            com.google.cloud.bigquery.BigQueryException.class,
+            () -> BigQueryService.createOrAdoptJob(connection, jobInfo, logger())
+        );
+
+        assertThat(thrown.getCode(), is(HttpURLConnection.HTTP_CONFLICT));
+    }
+
+    @Test
+    void shouldNotSwallowAnErrorThatIsNotAConflict() {
+        var connection = Mockito.mock(BigQuery.class);
+        var jobInfo = jobInfo("kestra_exec_taskrun");
+
+        Mockito.when(connection.create(jobInfo))
+            .thenThrow(new com.google.cloud.bigquery.BigQueryException(403, "Access Denied"));
+
+        var thrown = assertThrows(
+            com.google.cloud.bigquery.BigQueryException.class,
+            () -> BigQueryService.createOrAdoptJob(connection, jobInfo, logger())
+        );
+
+        assertThat(thrown.getCode(), is(403));
+        Mockito.verify(connection, Mockito.never()).getJob(Mockito.any(JobId.class));
+    }
+
+    private static com.google.cloud.bigquery.BigQueryException conflict() {
+        return new com.google.cloud.bigquery.BigQueryException(
+            HttpURLConnection.HTTP_CONFLICT,
+            "Already Exists: Job my-project:kestra_exec_taskrun"
+        );
+    }
+
+    private static JobInfo jobInfo(String job) {
+        return JobInfo.newBuilder(CONFIGURATION)
+            .setJobId(JobId.newBuilder().setProject("my-project").setLocation("EU").setJob(job).build())
+            .build();
+    }
+
+    private static Job job(BigQueryError error) {
+        var status = Mockito.mock(JobStatus.class);
+        Mockito.when(status.getError()).thenReturn(error);
+        Mockito.when(status.getState()).thenReturn(error == null ? JobStatus.State.RUNNING : JobStatus.State.DONE);
+
+        var job = Mockito.mock(Job.class);
+        Mockito.when(job.getStatus()).thenReturn(status);
+
+        return job;
+    }
+
+    private org.slf4j.Logger logger() {
+        return org.slf4j.LoggerFactory.getLogger(BigQueryJobIdTest.class);
+    }
+
+    private Query task() {
+        return Query.builder()
+            .id(BigQueryJobIdTest.class.getSimpleName())
+            .type(Query.class.getName())
+            .projectId(Property.ofValue("my-project"))
+            .location(Property.ofValue("EU"))
+            .sql(Property.ofValue("SELECT 1"))
+            .build();
+    }
+}

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/BigQueryJobIdTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/BigQueryJobIdTest.java
@@ -17,6 +17,7 @@ import com.google.common.collect.ImmutableMap;
 
 import io.kestra.core.junit.annotations.KestraTest;
 import io.kestra.core.models.property.Property;
+import io.kestra.core.runners.RunContext;
 import io.kestra.core.runners.RunContextFactory;
 import io.kestra.core.utils.TestsUtils;
 
@@ -51,21 +52,27 @@ class BigQueryJobIdTest {
 
         assertThat(jobId.getJob(), notNullValue());
         assertThat(jobId.getJob(), startsWith("kestra_"));
-        assertThat(jobId.getJob(), is("kestra_" + runContext.taskRunInfo().executionId() + "_" + runContext.taskRunInfo().taskRunId()));
+        assertThat(jobId.getJob(), is("kestra_" + runContext.taskRunInfo().taskRunId()));
     }
 
     @Test
-    void shouldGiveTheSameJobIdToEveryAttemptOfATaskrun() throws Exception {
-        var task = task();
-        var runContext = TestsUtils.mockRunContext(runContextFactory, task, ImmutableMap.of());
+    void shouldGiveTheSameJobIdToTwoContextsBuiltForTheSameTaskrun() throws Exception {
+        // A resubmit builds a fresh RunContext on another worker, so the two must agree. Two separately
+        // built contexts, not one context asked twice, which a pure function would satisfy trivially.
+        var first = BigQueryService.jobId(contextOf("taskrun-1"), task()).getJob();
+        var second = BigQueryService.jobId(contextOf("taskrun-1"), task()).getJob();
 
-        // The whole point: a resubmit on another worker must land on the id the lost worker used.
-        // Compare the job segment, not the whole JobId: two absent ids also compare equal.
-        var first = BigQueryService.jobId(runContext, task).getJob();
-        var second = BigQueryService.jobId(runContext, task).getJob();
-
-        assertThat(first, notNullValue());
+        assertThat(first, is("kestra_taskrun-1"));
         assertThat(second, is(first));
+    }
+
+    @Test
+    void shouldLeaveTheJobIdUnsetWithoutATaskrun() throws Exception {
+        // A trigger evaluates outside any execution. Deriving an id from a missing taskrun once gave every
+        // poll of every trigger the literal "kestra_null_null", so the first job was adopted forever.
+        var jobId = BigQueryService.jobId(runContextFactory.of(ImmutableMap.of()), task());
+
+        assertThat("BigQuery must assign a random id when there is no taskrun to key on", jobId.getJob(), nullValue());
     }
 
     @Test
@@ -177,6 +184,10 @@ class BigQueryJobIdTest {
 
     private org.slf4j.Logger logger() {
         return org.slf4j.LoggerFactory.getLogger(BigQueryJobIdTest.class);
+    }
+
+    private RunContext contextOf(String taskRunId) {
+        return runContextFactory.of(ImmutableMap.of("taskrun", ImmutableMap.of("id", taskRunId)));
     }
 
     private Query task() {

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/BigQueryJobIdTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/BigQueryJobIdTest.java
@@ -24,6 +24,7 @@ import io.kestra.core.utils.TestsUtils;
 import jakarta.inject.Inject;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -100,6 +101,22 @@ class BigQueryJobIdTest {
     }
 
     @Test
+    void shouldAdoptAnAlreadyFinishedJobWhenTheIdIsAlreadyTaken() {
+        var connection = Mockito.mock(BigQuery.class);
+        var jobInfo = jobInfo("kestra_taskrun");
+        var finished = job(null, JobStatus.State.DONE);
+
+        // The resubmit can land after the original already succeeded, and its result is the answer.
+        Mockito.when(connection.create(jobInfo)).thenThrow(conflict());
+        Mockito.when(connection.getJob(jobInfo.getJobId())).thenReturn(finished);
+
+        var adopted = BigQueryService.createOrAdoptJob(connection, jobInfo, logger());
+
+        assertThat("a finished job with no error is the outcome, not a reason to rerun", adopted, is(finished));
+        Mockito.verify(connection, Mockito.times(1)).create(Mockito.any(JobInfo.class));
+    }
+
+    @Test
     void shouldStartAFreshJobWhenTheTakenIdBelongsToAFailedJob() {
         var connection = Mockito.mock(BigQuery.class);
         var jobInfo = jobInfo("kestra_exec_taskrun");
@@ -159,12 +176,16 @@ class BigQueryJobIdTest {
     }
 
     @Test
-    void shouldNotFailOnASubmissionThatCameBackWithoutAStatus() throws Exception {
-        // Supplying our own job id makes the client answer some submissions with a bare job reference.
+    void shouldRefuseToReportOnAJobWithoutAStatus() {
+        // Never silently pass a job whose state is unknown: a dry run is not polled afterwards, so this
+        // is its only check.
         var job = Mockito.mock(Job.class);
         Mockito.when(job.getStatus()).thenReturn(null);
+        Mockito.when(job.getJobId()).thenReturn(JobId.of("my-project", "kestra_taskrun"));
 
-        BigQueryService.handleErrors(job, logger());
+        var thrown = assertThrows(IllegalStateException.class, () -> BigQueryService.handleErrors(job, logger()));
+
+        assertThat(thrown.getMessage(), containsString("no status to report"));
     }
 
     private static com.google.cloud.bigquery.BigQueryException conflict() {
@@ -181,9 +202,13 @@ class BigQueryJobIdTest {
     }
 
     private static Job job(BigQueryError error) {
+        return job(error, error == null ? JobStatus.State.RUNNING : JobStatus.State.DONE);
+    }
+
+    private static Job job(BigQueryError error, JobStatus.State state) {
         var status = Mockito.mock(JobStatus.class);
         Mockito.when(status.getError()).thenReturn(error);
-        Mockito.when(status.getState()).thenReturn(error == null ? JobStatus.State.RUNNING : JobStatus.State.DONE);
+        Mockito.when(status.getState()).thenReturn(state);
 
         var job = Mockito.mock(Job.class);
         Mockito.when(job.getStatus()).thenReturn(status);

--- a/src/test/java/io/kestra/plugin/gcp/bigquery/BigQueryJobIdTest.java
+++ b/src/test/java/io/kestra/plugin/gcp/bigquery/BigQueryJobIdTest.java
@@ -158,6 +158,15 @@ class BigQueryJobIdTest {
         Mockito.verify(connection, Mockito.never()).getJob(Mockito.any(JobId.class));
     }
 
+    @Test
+    void shouldNotFailOnASubmissionThatCameBackWithoutAStatus() throws Exception {
+        // Supplying our own job id makes the client answer some submissions with a bare job reference.
+        var job = Mockito.mock(Job.class);
+        Mockito.when(job.getStatus()).thenReturn(null);
+
+        BigQueryService.handleErrors(job, logger());
+    }
+
     private static com.google.cloud.bigquery.BigQueryException conflict() {
         return new com.google.cloud.bigquery.BigQueryException(
             HttpURLConnection.HTTP_CONFLICT,


### PR DESCRIPTION
Closes #674

`BigQueryService.jobId()` set only project and location and never called `setJob(...)`, so BigQuery assigned a random id on every submission. A worker-loss resubmit therefore started a **second** job doing the same work, with the original still running and invisible to Kestra. For a `Query` that writes, or a load, that is duplicated data as well as duplicated cost.

Deriving the id from the execution and taskrun makes the resubmit collide with the job the lost worker started, and BigQuery's caller-supplied job id is its documented dedup mechanism.

## Changes

- `BigQueryService.jobId()` now sets `kestra_<executionId>_<taskRunId>`, read from `runContext.taskRunInfo()`.
- New `BigQueryService.createOrAdoptJob()` handles a taken id: fetch the existing job and wait on it.
- Applied to `Query`, `Copy`, `LoadFromGcs`, and `ExtractToGcs`.
- A line in each task's description, so the behavior is discoverable next to `RunTransferConfig`'s `reattach`.

## Two departures from the issue

**BigQuery does not return the existing job.** The issue says a duplicate id "returns the existing job instead of creating a second one". It returns `409 ALREADY_EXISTS`. The dedup is real, but the caller gets an exception, not the job. Implemented literally, a resubmit would fail with "Already Exists" rather than adopting, trading duplicated data for a hard failure. So the conflict is caught and the job fetched explicitly.

**No attempt number in the id.** The issue proposes attempt entropy so a retry gets a fresh job. `TaskRunInfo` does not expose `attemptsCount`, and it is not clearly stable across a resubmit: `onRunningResend()` appends an attempt when the list is empty but replaces in place when it is not.

`plugin-dbt`'s `TriggerRun` already solved this without attempt entropy, keying on the taskrun alone and deciding from the found run's state:

> Adopt an in-flight or succeeded run, but never an Error or Cancelled one, so a genuine failure lets the retry or restart re-trigger instead of re-reporting the old failure.

One part does not carry over. dbt Cloud assigns its own run ids, so it can simply trigger a new run. BigQuery reserves the id we supply, so a failed job's id is unusable forever. Hence the extra branch: on a conflict with a job that is `DONE` and carries an error, resubmit with a random id. Without it, retries on these tasks would be permanently broken.

**Execution id dropped from the derived id.** The issue asked for execution id plus taskrun id. At the Kestra version this builds against, `taskRunInfo().executionId()` returns null even for a real task run, so concatenating it produced a literal `null` segment and a null check on it would have disabled the feature entirely. The id keys on `taskRunId` alone, which is an `IdUtils.create()` value already carrying full entropy, so the issue's uniqueness requirement is met without it. The execution id only added traceability, which is not worth depending on a field that is not populated.

## Beyond the issue's list

`ExtractToGcs` submitted `JobInfo.of(configuration)` with no job id at all and has the same defect. Included rather than left as the only one still broken.

`Load` is **not** covered. It creates its job through a `TableDataWriteChannel` rather than `connection.create`, so supplying an id there is a different change with different failure modes. Worth a separate issue.

## Tests

`BigQueryJobIdTest`, 7 tests, Mockito against a mock `BigQuery`, no credentials needed. 48 pass across the credential-free BigQuery suites.

- id is derived from the taskrun, stable across calls, distinct across taskruns
- a taken id whose job is running is adopted, and `create` is called exactly once
- a taken id whose job failed falls back to a random id, asserted on the resubmitted `JobInfo`
- a conflict whose job cannot be fetched is rethrown
- a non-409 error is not swallowed and never triggers a fetch

Verified the id tests are not vacuous: all three fail with `setJob(...)` removed. The first version of the stability test passed against the reverted code, since two absent job ids compare equal, so it now compares the job segment and asserts non-null.

## Note for review

This is always-on rather than an opt-in property. `plugin-dbt` made its `reattach` opt-in because it mutates a user-authored `cause` string, so upgrading changes nothing for existing flows. A BigQuery job id is not user-authored, so the same argument does not apply here, but it is a judgment call worth confirming.